### PR TITLE
refactor: Make recipe implementation functions accept individual config properties rather than accepting the config object directly

### DIFF
--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -1,9 +1,10 @@
 import { NormalisedAppInfo } from "./types";
 import {
-    NormalisedRecipeConfig,
     PostAPIHookFunction,
     PreAPIHookFunction,
     RecipeFunctionOptions,
+    RecipePostAPIHookFunction,
+    RecipePreAPIHookFunction,
 } from "./recipe/recipeModule/types";
 /**
  * When network calls are made the Querier calls .clone() on the response before:
@@ -69,22 +70,22 @@ export default class Querier {
     getFullUrl: (pathStr: string, queryParams?: Record<string, string> | undefined) => string;
     getResponseJsonOrThrowGeneralError: (response: Response) => Promise<any>;
     static preparePreAPIHook: <Action>({
-        config,
+        recipePreAPIHook,
         action,
         options,
         userContext,
     }: {
-        config: NormalisedRecipeConfig<Action>;
+        recipePreAPIHook: RecipePreAPIHookFunction<Action>;
         action: Action;
         options?: RecipeFunctionOptions | undefined;
         userContext: any;
     }) => PreAPIHookFunction;
     static preparePostAPIHook: <Action>({
-        config,
+        recipePostAPIHook,
         action,
         userContext,
     }: {
-        config: NormalisedRecipeConfig<Action>;
+        recipePostAPIHook: RecipePostAPIHookFunction<Action>;
         action: Action;
         userContext: any;
     }) => PostAPIHookFunction;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -422,7 +422,7 @@ var Querier = /** @class */ (function () {
     var _a;
     _a = Querier;
     Querier.preparePreAPIHook = function (_b) {
-        var config = _b.config,
+        var recipePreAPIHook = _b.recipePreAPIHook,
             action = _b.action,
             options = _b.options,
             userContext = _b.userContext;
@@ -434,7 +434,7 @@ var Querier = /** @class */ (function () {
                         case 0:
                             return [
                                 4 /*yield*/,
-                                config.preAPIHook(
+                                recipePreAPIHook(
                                     __assign(__assign({}, context), { action: action, userContext: userContext })
                                 ),
                             ];
@@ -457,7 +457,7 @@ var Querier = /** @class */ (function () {
         };
     };
     Querier.preparePostAPIHook = function (_b) {
-        var config = _b.config,
+        var recipePostAPIHook = _b.recipePostAPIHook,
             action = _b.action,
             userContext = _b.userContext;
         return function (context) {
@@ -467,7 +467,7 @@ var Querier = /** @class */ (function () {
                         case 0:
                             return [
                                 4 /*yield*/,
-                                config.postAPIHook(
+                                recipePostAPIHook(
                                     __assign(__assign({}, context), { userContext: userContext, action: action })
                                 ),
                             ];

--- a/lib/build/recipe/emailpassword/index.d.ts
+++ b/lib/build/recipe/emailpassword/index.d.ts
@@ -100,15 +100,15 @@ export default class RecipeWrapper {
         doesExist: boolean;
         fetchResponse: Response;
     }>;
-    static verifyEmail(input: { token?: string; options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static verifyEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
-    static sendVerificationEmail(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static sendVerificationEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
-    static isEmailVerified(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static isEmailVerified(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -163,61 +163,50 @@ var RecipeWrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     RecipeWrapper.submitNewPassword = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.submitNewPassword(
-            __assign(__assign({}, input), {
-                config: recipeInstance.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.submitNewPassword(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.sendPasswordResetEmail = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.sendPasswordResetEmail(
-            __assign(__assign({}, input), {
-                config: recipeInstance.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.sendPasswordResetEmail(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.signUp = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.signUp(
-            __assign(__assign({}, input), {
-                config: recipeInstance.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.signUp(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.signIn = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.signIn(
-            __assign(__assign({}, input), {
-                config: recipeInstance.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.signIn(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.doesEmailExist = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.doesEmailExist(
-            __assign(__assign({}, input), {
-                config: recipeInstance.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.doesEmailExist(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.verifyEmail = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.verifyEmail(
+                    recipe_1.default.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.verifyEmail(
                         __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
+                            userContext: (0, utils_1.getNormalisedUserContext)(
+                                input === null || input === void 0 ? void 0 : input.userContext
+                            ),
                         })
                     ),
                 ];
@@ -226,32 +215,32 @@ var RecipeWrapper = /** @class */ (function () {
     };
     RecipeWrapper.sendVerificationEmail = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.sendVerificationEmail(
-                        __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-                        })
-                    ),
+                    recipe_1.default
+                        .getInstanceOrThrow()
+                        .emailVerificationRecipe.recipeImplementation.sendVerificationEmail(
+                            __assign(__assign({}, input), {
+                                userContext: (0, utils_1.getNormalisedUserContext)(
+                                    input === null || input === void 0 ? void 0 : input.userContext
+                                ),
+                            })
+                        ),
                 ];
             });
         });
     };
     RecipeWrapper.isEmailVerified = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.isEmailVerified(
+                    recipe_1.default.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.isEmailVerified(
                         __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
+                            userContext: (0, utils_1.getNormalisedUserContext)(
+                                input === null || input === void 0 ? void 0 : input.userContext
+                            ),
                         })
                     ),
                 ];

--- a/lib/build/recipe/emailpassword/recipe.js
+++ b/lib/build/recipe/emailpassword/recipe.js
@@ -63,7 +63,12 @@ var Recipe = /** @class */ (function (_super) {
     function Recipe(config, recipes) {
         var _this = _super.call(this, (0, utils_1.normaliseUserInput)(config), recipes) || this;
         var builder = new supertokens_js_override_1.default(
-            (0, recipeImplementation_1.default)(_this.config.recipeId, _this.config.appInfo)
+            (0, recipeImplementation_1.default)(
+                _this.config.recipeId,
+                _this.config.appInfo,
+                _this.config.preAPIHook,
+                _this.config.postAPIHook
+            )
         );
         _this.recipeImplementation = builder.override(_this.config.override.functions).build();
         return _this;

--- a/lib/build/recipe/emailpassword/recipeImplementation.d.ts
+++ b/lib/build/recipe/emailpassword/recipeImplementation.d.ts
@@ -1,3 +1,9 @@
-import { RecipeInterface } from "./types";
+import { PreAndPostAPIHookAction, RecipeInterface } from "./types";
+import { RecipePostAPIHookFunction, RecipePreAPIHookFunction } from "../recipeModule/types";
 import { NormalisedAppInfo } from "../../types";
-export default function getRecipeImplementation(recipeId: string, appInfo: NormalisedAppInfo): RecipeInterface;
+export default function getRecipeImplementation(
+    recipeId: string,
+    appInfo: NormalisedAppInfo,
+    preAPIHook: RecipePreAPIHookFunction<PreAndPostAPIHookAction>,
+    postAPIHook: RecipePostAPIHookFunction<PreAndPostAPIHookAction>
+): RecipeInterface;

--- a/lib/build/recipe/emailpassword/recipeImplementation.js
+++ b/lib/build/recipe/emailpassword/recipeImplementation.js
@@ -147,12 +147,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 var querier_1 = require("../../querier");
 var utils_1 = require("../../utils");
-function getRecipeImplementation(recipeId, appInfo) {
+function getRecipeImplementation(recipeId, appInfo, preAPIHook, postAPIHook) {
     var querier = new querier_1.default(recipeId, appInfo);
     return {
         submitNewPassword: function (_a) {
             var formFields = _a.formFields,
-                config = _a.config,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
@@ -161,7 +160,6 @@ function getRecipeImplementation(recipeId, appInfo) {
                     switch (_c.label) {
                         case 0:
                             token = this.getResetPasswordTokenFromURL({
-                                config: config,
                                 userContext: userContext,
                             });
                             return [
@@ -170,13 +168,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     "/user/password/reset",
                                     { body: JSON.stringify({ formFields: formFields, token: token, method: "token" }) },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "SUBMIT_NEW_PASSWORD",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "SUBMIT_NEW_PASSWORD",
                                         userContext: userContext,
                                     })
@@ -207,7 +205,6 @@ function getRecipeImplementation(recipeId, appInfo) {
         },
         sendPasswordResetEmail: function (_a) {
             var formFields = _a.formFields,
-                config = _a.config,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
@@ -221,13 +218,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     "/user/password/reset/token",
                                     { body: JSON.stringify({ formFields: formFields }) },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "SEND_RESET_PASSWORD_EMAIL",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "SEND_RESET_PASSWORD_EMAIL",
                                         userContext: userContext,
                                     })
@@ -258,7 +255,6 @@ function getRecipeImplementation(recipeId, appInfo) {
         },
         signUp: function (_a) {
             var formFields = _a.formFields,
-                config = _a.config,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
@@ -272,13 +268,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     "/signup",
                                     { body: JSON.stringify({ formFields: formFields }) },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "EMAIL_PASSWORD_SIGN_UP",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "EMAIL_PASSWORD_SIGN_UP",
                                         userContext: userContext,
                                     })
@@ -310,7 +306,6 @@ function getRecipeImplementation(recipeId, appInfo) {
         },
         signIn: function (_a) {
             var formFields = _a.formFields,
-                config = _a.config,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
@@ -324,13 +319,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     "/signin",
                                     { body: JSON.stringify({ formFields: formFields }) },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "EMAIL_PASSWORD_SIGN_IN",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "EMAIL_PASSWORD_SIGN_IN",
                                         userContext: userContext,
                                     })
@@ -371,7 +366,6 @@ function getRecipeImplementation(recipeId, appInfo) {
         },
         doesEmailExist: function (_a) {
             var email = _a.email,
-                config = _a.config,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
@@ -386,13 +380,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     {},
                                     { email: email },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "EMAIL_EXISTS",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "EMAIL_EXISTS",
                                         userContext: userContext,
                                     })

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -38,7 +38,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -60,7 +59,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -82,7 +80,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -105,7 +102,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -127,15 +123,10 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
     >;
-    doesEmailExist: (input: {
-        email: string;
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    doesEmailExist: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
     }>;
-    getResetPasswordTokenFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getResetPasswordTokenFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/build/recipe/emailverification/index.d.ts
+++ b/lib/build/recipe/emailverification/index.d.ts
@@ -4,15 +4,15 @@ export default class RecipeWrapper {
     static init(
         config?: InputType
     ): import("../../types").CreateRecipeFunction<import("./types").PreAndPostAPIHookAction>;
-    static verifyEmail(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static verifyEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
-    static sendVerificationEmail(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static sendVerificationEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
-    static isEmailVerified(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static isEmailVerified(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;

--- a/lib/build/recipe/emailverification/index.js
+++ b/lib/build/recipe/emailverification/index.js
@@ -1,4 +1,18 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isEmailVerified = exports.sendVerificationEmail = exports.verifyEmail = exports.init = void 0;
 var recipe_1 = require("./recipe");
@@ -9,28 +23,31 @@ var RecipeWrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     RecipeWrapper.verifyEmail = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.verifyEmail({
-            options: input.options,
-            config: recipeInstance.config,
-            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-        });
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.verifyEmail(
+            __assign(__assign({}, input), {
+                userContext: (0, utils_1.getNormalisedUserContext)(
+                    input === null || input === void 0 ? void 0 : input.userContext
+                ),
+            })
+        );
     };
     RecipeWrapper.sendVerificationEmail = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.sendVerificationEmail({
-            options: input.options,
-            config: recipeInstance.config,
-            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-        });
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.sendVerificationEmail(
+            __assign(__assign({}, input), {
+                userContext: (0, utils_1.getNormalisedUserContext)(
+                    input === null || input === void 0 ? void 0 : input.userContext
+                ),
+            })
+        );
     };
     RecipeWrapper.isEmailVerified = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.isEmailVerified({
-            options: input.options,
-            config: recipeInstance.config,
-            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-        });
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.isEmailVerified(
+            __assign(__assign({}, input), {
+                userContext: (0, utils_1.getNormalisedUserContext)(
+                    input === null || input === void 0 ? void 0 : input.userContext
+                ),
+            })
+        );
     };
     return RecipeWrapper;
 })();

--- a/lib/build/recipe/emailverification/recipe.js
+++ b/lib/build/recipe/emailverification/recipe.js
@@ -36,7 +36,12 @@ var Recipe = /** @class */ (function () {
     function Recipe(config) {
         this.config = (0, utils_1.normaliseUserInput)(config);
         var builder = new supertokens_js_override_1.default(
-            (0, recipeImplementation_1.default)(this.config.recipeId, this.config.appInfo)
+            (0, recipeImplementation_1.default)(
+                this.config.recipeId,
+                this.config.appInfo,
+                this.config.preAPIHook,
+                this.config.postAPIHook
+            )
         );
         this.recipeImplementation = builder.override(this.config.override.functions).build();
     }

--- a/lib/build/recipe/emailverification/recipeImplementation.d.ts
+++ b/lib/build/recipe/emailverification/recipeImplementation.d.ts
@@ -1,3 +1,9 @@
 import { NormalisedAppInfo } from "../../types";
-import { RecipeInterface } from "./types";
-export default function getRecipeImplementation(recipeId: string, appInfo: NormalisedAppInfo): RecipeInterface;
+import { RecipePostAPIHookFunction, RecipePreAPIHookFunction } from "../recipeModule/types";
+import { PreAndPostAPIHookAction, RecipeInterface } from "./types";
+export default function getRecipeImplementation(
+    recipeId: string,
+    appInfo: NormalisedAppInfo,
+    preAPIHook: RecipePreAPIHookFunction<PreAndPostAPIHookAction>,
+    postAPIHook: RecipePostAPIHookFunction<PreAndPostAPIHookAction>
+): RecipeInterface;

--- a/lib/build/recipe/emailverification/recipeImplementation.js
+++ b/lib/build/recipe/emailverification/recipeImplementation.js
@@ -147,12 +147,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 var querier_1 = require("../../querier");
 var utils_1 = require("../../utils");
-function getRecipeImplementation(recipeId, appInfo) {
+function getRecipeImplementation(recipeId, appInfo, preAPIHook, postAPIHook) {
     var querier = new querier_1.default(recipeId, appInfo);
     return {
         verifyEmail: function (_a) {
-            var config = _a.config,
-                options = _a.options,
+            var options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
                 var token, _b, jsonBody, fetchResponse;
@@ -160,7 +159,6 @@ function getRecipeImplementation(recipeId, appInfo) {
                     switch (_c.label) {
                         case 0:
                             token = this.getEmailVerificationTokenFromURL({
-                                config: config,
                                 userContext: userContext,
                             });
                             return [
@@ -174,13 +172,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                         }),
                                     },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "VERIFY_EMAIL",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         userContext: userContext,
                                         action: "VERIFY_EMAIL",
                                     })
@@ -200,8 +198,7 @@ function getRecipeImplementation(recipeId, appInfo) {
             });
         },
         isEmailVerified: function (_a) {
-            var config = _a.config,
-                options = _a.options,
+            var options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
                 var _b, jsonBody, fetchResponse;
@@ -215,13 +212,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     {},
                                     undefined,
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "IS_EMAIL_VERIFIED",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         userContext: userContext,
                                         action: "IS_EMAIL_VERIFIED",
                                     })
@@ -242,8 +239,7 @@ function getRecipeImplementation(recipeId, appInfo) {
             });
         },
         sendVerificationEmail: function (_a) {
-            var config = _a.config,
-                options = _a.options,
+            var options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
                 var _b, jsonBody, fetchResponse;
@@ -256,13 +252,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     "/user/email/verify/token",
                                     { body: JSON.stringify({}) },
                                     querier_1.default.preparePreAPIHook({
-                                        config: config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "SEND_VERIFY_EMAIL",
                                         options: options,
                                         userContext: userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: config,
+                                        recipePostAPIHook: postAPIHook,
                                         userContext: userContext,
                                         action: "SEND_VERIFY_EMAIL",
                                     })

--- a/lib/build/recipe/emailverification/types.d.ts
+++ b/lib/build/recipe/emailverification/types.d.ts
@@ -26,30 +26,18 @@ export declare type NormalisedInputType = NormalisedRecipeConfig<PreAndPostAPIHo
     };
 };
 export declare type RecipeInterface = {
-    verifyEmail: (input: {
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    verifyEmail: (input: { options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
-    sendVerificationEmail: (input: {
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    sendVerificationEmail: (input: { options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
-    isEmailVerified: (input: {
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    isEmailVerified: (input: { options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }>;
-    getEmailVerificationTokenFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getEmailVerificationTokenFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/build/recipe/recipeModule/types.d.ts
+++ b/lib/build/recipe/recipeModule/types.d.ts
@@ -21,23 +21,22 @@ export declare type PostAPIHookFunction = (context: {
     url: string;
     fetchResponse: Response;
 }) => Promise<void>;
+export declare type RecipePreAPIHookFunction<Action> = (context: RecipePreAPIHookContext<Action>) => Promise<{
+    url: string;
+    requestInit: RequestInit;
+}>;
+export declare type RecipePostAPIHookFunction<Action> = (context: RecipePostAPIHookContext<Action>) => Promise<void>;
 export declare type RecipeConfig<Action> = {
     recipeId: string;
     appInfo: NormalisedAppInfo;
-    preAPIHook?: (context: RecipePreAPIHookContext<Action>) => Promise<{
-        url: string;
-        requestInit: RequestInit;
-    }>;
-    postAPIHook?: (context: RecipePostAPIHookContext<Action>) => Promise<void>;
+    preAPIHook?: RecipePreAPIHookFunction<Action>;
+    postAPIHook?: RecipePostAPIHookFunction<Action>;
 };
 export declare type NormalisedRecipeConfig<Action> = {
     recipeId: string;
     appInfo: NormalisedAppInfo;
-    preAPIHook: (context: RecipePreAPIHookContext<Action>) => Promise<{
-        url: string;
-        requestInit: RequestInit;
-    }>;
-    postAPIHook: (context: RecipePostAPIHookContext<Action>) => Promise<void>;
+    preAPIHook: RecipePreAPIHookFunction<Action>;
+    postAPIHook: RecipePostAPIHookFunction<Action>;
 };
 /**
  * For the options object passed to recipe functions, we do not need a postAPIHook.

--- a/lib/build/recipe/thirdparty/index.d.ts
+++ b/lib/build/recipe/thirdparty/index.d.ts
@@ -29,15 +29,15 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     >;
-    static verifyEmail(input: { token?: string; options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static verifyEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
-    static sendVerificationEmail(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static sendVerificationEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
-    static isEmailVerified(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static isEmailVerified(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -174,19 +174,15 @@ var RecipeWrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     RecipeWrapper.getAuthorizationURLWithQueryParamsAndSetState = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState(
-            __assign(__assign({}, input), {
-                config: recipeInstance.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.signInAndUp = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.signInAndUp(
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.signInAndUp(
             __assign(__assign({}, input), {
-                config: recipeInstance.config,
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -195,15 +191,14 @@ var RecipeWrapper = /** @class */ (function () {
     };
     RecipeWrapper.verifyEmail = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.verifyEmail(
+                    recipe_1.default.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.verifyEmail(
                         __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
+                            userContext: (0, utils_1.getNormalisedUserContext)(
+                                input === null || input === void 0 ? void 0 : input.userContext
+                            ),
                         })
                     ),
                 ];
@@ -212,32 +207,32 @@ var RecipeWrapper = /** @class */ (function () {
     };
     RecipeWrapper.sendVerificationEmail = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.sendVerificationEmail(
-                        __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-                        })
-                    ),
+                    recipe_1.default
+                        .getInstanceOrThrow()
+                        .emailVerificationRecipe.recipeImplementation.sendVerificationEmail(
+                            __assign(__assign({}, input), {
+                                userContext: (0, utils_1.getNormalisedUserContext)(
+                                    input === null || input === void 0 ? void 0 : input.userContext
+                                ),
+                            })
+                        ),
                 ];
             });
         });
     };
     RecipeWrapper.isEmailVerified = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.isEmailVerified(
+                    recipe_1.default.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.isEmailVerified(
                         __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
+                            userContext: (0, utils_1.getNormalisedUserContext)(
+                                input === null || input === void 0 ? void 0 : input.userContext
+                            ),
                         })
                     ),
                 ];

--- a/lib/build/recipe/thirdparty/recipe.js
+++ b/lib/build/recipe/thirdparty/recipe.js
@@ -63,7 +63,12 @@ var Recipe = /** @class */ (function (_super) {
     function Recipe(config, recipes) {
         var _this = _super.call(this, (0, utils_1.normaliseUserInput)(config), recipes) || this;
         var builder = new supertokens_js_override_1.default(
-            (0, recipeImplementation_1.default)(_this.config.recipeId, _this.config.appInfo)
+            (0, recipeImplementation_1.default)(
+                _this.config.recipeId,
+                _this.config.appInfo,
+                _this.config.preAPIHook,
+                _this.config.postAPIHook
+            )
         );
         _this.recipeImplementation = builder.override(_this.config.override.functions).build();
         return _this;

--- a/lib/build/recipe/thirdparty/recipeImplementation.d.ts
+++ b/lib/build/recipe/thirdparty/recipeImplementation.d.ts
@@ -1,3 +1,10 @@
-import { NormalisedAppInfo } from "../../types";
 import { RecipeInterface } from "./types";
-export default function getRecipeImplementation(recipeId: string, appInfo: NormalisedAppInfo): RecipeInterface;
+import { RecipePostAPIHookFunction, RecipePreAPIHookFunction } from "../recipeModule/types";
+import { NormalisedAppInfo } from "../../types";
+import { PreAndPostAPIHookAction } from "./types";
+export default function getRecipeImplementation(
+    recipeId: string,
+    appInfo: NormalisedAppInfo,
+    preAPIHook: RecipePreAPIHookFunction<PreAndPostAPIHookAction>,
+    postAPIHook: RecipePostAPIHookFunction<PreAndPostAPIHookAction>
+): RecipeInterface;

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -162,7 +162,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var querier_1 = require("../../querier");
 var utils_1 = require("../../utils");
 var error_1 = require("../../error");
-function getRecipeImplementation(recipeId, appInfo) {
+function getRecipeImplementation(recipeId, appInfo, preAPIHook, postAPIHook) {
     var querier = new querier_1.default(recipeId, appInfo);
     return {
         getStateAndOtherInfoFromStorage: function () {
@@ -193,7 +193,6 @@ function getRecipeImplementation(recipeId, appInfo) {
                         case 0:
                             stateToSendToAuthProvider = this.generateStateToSendToOAuthProvider({
                                 userContext: input.userContext,
-                                config: input.config,
                             });
                             stateExpiry = Date.now() + 1000 * 60 * 10;
                             // 2. Store state in Session Storage.
@@ -206,13 +205,11 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     providerClientId: input.providerClientId,
                                 },
                                 userContext: input.userContext,
-                                config: input.config,
                             });
                             return [
                                 4 /*yield*/,
                                 this.getAuthorisationURLFromBackend({
                                     providerId: input.providerId,
-                                    config: input.config,
                                     userContext: input.userContext,
                                     options: input.options,
                                 }),
@@ -247,13 +244,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                     {},
                                     { thirdPartyId: input.providerId },
                                     querier_1.default.preparePreAPIHook({
-                                        config: input.config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "GET_AUTHORISATION_URL",
                                         options: input.options,
                                         userContext: input.userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: input.config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "GET_AUTHORISATION_URL",
                                         userContext: input.userContext,
                                     })
@@ -288,10 +285,8 @@ function getRecipeImplementation(recipeId, appInfo) {
                         case 0:
                             stateFromStorage = this.getStateAndOtherInfoFromStorage({
                                 userContext: input.userContext,
-                                config: input.config,
                             });
                             stateFromQueryParams = this.getAuthStateFromURL({
-                                config: input.config,
                                 userContext: input.userContext,
                             });
                             return [
@@ -299,7 +294,6 @@ function getRecipeImplementation(recipeId, appInfo) {
                                 this.verifyAndGetStateOrThrowError({
                                     stateFromAuthProvider: stateFromQueryParams,
                                     stateObjectFromStorage: stateFromStorage,
-                                    config: input.config,
                                     userContext: input.userContext,
                                 }),
                             ];
@@ -307,11 +301,9 @@ function getRecipeImplementation(recipeId, appInfo) {
                             verifiedState = _b.sent();
                             code = this.getAuthCodeFromURL({
                                 userContext: input.userContext,
-                                config: input.config,
                             });
                             errorInQuery = this.getAuthErrorFromURL({
                                 userContext: input.userContext,
-                                config: input.config,
                             });
                             if (errorInQuery !== undefined) {
                                 /**
@@ -338,13 +330,13 @@ function getRecipeImplementation(recipeId, appInfo) {
                                         }),
                                     },
                                     querier_1.default.preparePreAPIHook({
-                                        config: input.config,
+                                        recipePreAPIHook: preAPIHook,
                                         action: "THIRD_PARTY_SIGN_IN_UP",
                                         options: input.options,
                                         userContext: input.userContext,
                                     }),
                                     querier_1.default.preparePostAPIHook({
-                                        config: input.config,
+                                        recipePostAPIHook: postAPIHook,
                                         action: "THIRD_PARTY_SIGN_IN_UP",
                                         userContext: input.userContext,
                                     })

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -36,24 +36,20 @@ export declare type StateObject = {
 export declare type RecipeInterface = {
     getStateAndOtherInfoFromStorage: <CustomStateProperties>(input: {
         userContext: any;
-        config: NormalisedInputType;
     }) => (StateObject & CustomStateProperties) | undefined;
     setStateAndOtherInfoToStorage: <CustomStateProperties>(input: {
         state: StateObject & CustomStateProperties;
-        config: NormalisedInputType;
         userContext: any;
     }) => void;
     getAuthorizationURLWithQueryParamsAndSetState: (input: {
         providerId: string;
         authorisationURL: string;
-        config: NormalisedInputType;
         userContext: any;
         providerClientId?: string;
         options?: RecipeFunctionOptions;
     }) => Promise<string>;
     getAuthorisationURLFromBackend: (input: {
         providerId: string;
-        config: NormalisedInputType;
         userContext: any;
         options?: RecipeFunctionOptions;
     }) => Promise<{
@@ -61,7 +57,7 @@ export declare type RecipeInterface = {
         url: string;
         fetchResponse: Response;
     }>;
-    signInAndUp: (input: { config: NormalisedInputType; userContext: any; options?: RecipeFunctionOptions }) => Promise<
+    signInAndUp: (input: { userContext: any; options?: RecipeFunctionOptions }) => Promise<
         | {
               status: "OK";
               user: UserType;
@@ -73,14 +69,13 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
     >;
-    generateStateToSendToOAuthProvider: (input: { userContext: any; config: NormalisedInputType }) => string;
+    generateStateToSendToOAuthProvider: (input: { userContext: any }) => string;
     verifyAndGetStateOrThrowError: <CustomStateProperties>(input: {
         stateFromAuthProvider: string | undefined;
         stateObjectFromStorage: (StateObject & CustomStateProperties) | undefined;
-        config: NormalisedInputType;
         userContext: any;
     }) => Promise<StateObject & CustomStateProperties>;
-    getAuthCodeFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
-    getAuthErrorFromURL: (input: { config: NormalisedInputType; userContext: any }) => string | undefined;
-    getAuthStateFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getAuthCodeFromURL: (input: { userContext: any }) => string;
+    getAuthErrorFromURL: (input: { userContext: any }) => string | undefined;
+    getAuthStateFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/build/recipe/thirdpartyemailpassword/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/index.d.ts
@@ -119,15 +119,15 @@ export default class RecipeWrapper {
         providerClientId?: string;
         options?: RecipeFunctionOptions;
     }): Promise<string>;
-    static verifyEmail(input: { token?: string; options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static verifyEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
-    static sendVerificationEmail(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static sendVerificationEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
-    static isEmailVerified(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static isEmailVerified(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -179,55 +179,43 @@ var RecipeWrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     RecipeWrapper.submitNewPassword = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.submitNewPassword(
-            __assign(__assign({}, input), {
-                config: recipeInstance.emailPasswordRecipe.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.submitNewPassword(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.sendPasswordResetEmail = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.sendPasswordResetEmail(
-            __assign(__assign({}, input), {
-                config: recipeInstance.emailPasswordRecipe.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.sendPasswordResetEmail(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.doesEmailExist = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.doesEmailExist(
-            __assign(__assign({}, input), {
-                config: recipeInstance.emailPasswordRecipe.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.doesEmailExist(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.emailPasswordSignUp = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.emailPasswordSignUp(
-            __assign(__assign({}, input), {
-                config: recipeInstance.emailPasswordRecipe.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.emailPasswordSignUp(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.emailPasswordSignIn = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.emailPasswordSignIn(
-            __assign(__assign({}, input), {
-                config: recipeInstance.emailPasswordRecipe.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.emailPasswordSignIn(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.thirdPartySignInAndUp = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.thirdPartySignInAndUp(
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.thirdPartySignInAndUp(
             __assign(__assign({}, input), {
-                config: recipeInstance.thirdPartyRecipe.config,
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -235,25 +223,22 @@ var RecipeWrapper = /** @class */ (function () {
         );
     };
     RecipeWrapper.getAuthorizationURLWithQueryParamsAndSetState = function (input) {
-        var recipeInstance = recipe_1.default.getInstanceOrThrow();
-        return recipeInstance.recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState(
-            __assign(__assign({}, input), {
-                config: recipeInstance.thirdPartyRecipe.config,
-                userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-            })
-        );
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState(
+                __assign(__assign({}, input), { userContext: (0, utils_1.getNormalisedUserContext)(input.userContext) })
+            );
     };
     RecipeWrapper.verifyEmail = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.verifyEmail(
+                    recipe_1.default.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.verifyEmail(
                         __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
+                            userContext: (0, utils_1.getNormalisedUserContext)(
+                                input === null || input === void 0 ? void 0 : input.userContext
+                            ),
                         })
                     ),
                 ];
@@ -262,32 +247,32 @@ var RecipeWrapper = /** @class */ (function () {
     };
     RecipeWrapper.sendVerificationEmail = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.sendVerificationEmail(
-                        __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
-                        })
-                    ),
+                    recipe_1.default
+                        .getInstanceOrThrow()
+                        .emailVerificationRecipe.recipeImplementation.sendVerificationEmail(
+                            __assign(__assign({}, input), {
+                                userContext: (0, utils_1.getNormalisedUserContext)(
+                                    input === null || input === void 0 ? void 0 : input.userContext
+                                ),
+                            })
+                        ),
                 ];
             });
         });
     };
     RecipeWrapper.isEmailVerified = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipeInstance;
             return __generator(this, function (_a) {
-                recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
-                    recipeInstance.emailVerificationRecipe.recipeImplementation.isEmailVerified(
+                    recipe_1.default.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.isEmailVerified(
                         __assign(__assign({}, input), {
-                            config: recipeInstance.emailVerificationRecipe.config,
-                            userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
+                            userContext: (0, utils_1.getNormalisedUserContext)(
+                                input === null || input === void 0 ? void 0 : input.userContext
+                            ),
                         })
                     ),
                 ];

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.js
@@ -68,7 +68,12 @@ var Recipe = /** @class */ (function (_super) {
         var _a, _b;
         var _this = _super.call(this, (0, utils_1.normaliseUserInput)(config), recipes) || this;
         var builder = new supertokens_js_override_1.default(
-            (0, recipeImplementation_1.default)(_this.config.recipeId, _this.config.appInfo)
+            (0, recipeImplementation_1.default)(
+                _this.config.recipeId,
+                _this.config.appInfo,
+                _this.config.preAPIHook,
+                _this.config.postAPIHook
+            )
         );
         var _recipeImplementation = builder.override(_this.config.override.functions).build();
         _this.recipeImplementation = _recipeImplementation;

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
@@ -1,3 +1,9 @@
 import { NormalisedAppInfo } from "../../../types";
-import { RecipeInterface } from "../types";
-export default function getRecipeImplementation(recipeId: string, appInfo: NormalisedAppInfo): RecipeInterface;
+import { PreAndPostAPIHookAction, RecipeInterface } from "../types";
+import { RecipePostAPIHookFunction, RecipePreAPIHookFunction } from "../../recipeModule/types";
+export default function getRecipeImplementation(
+    recipeId: string,
+    appInfo: NormalisedAppInfo,
+    preAPIHook: RecipePreAPIHookFunction<PreAndPostAPIHookAction>,
+    postAPIHook: RecipePostAPIHookFunction<PreAndPostAPIHookAction>
+): RecipeInterface;

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
@@ -149,9 +149,9 @@ var recipeImplementation_1 = require("../../emailpassword/recipeImplementation")
 var recipeImplementation_2 = require("../../thirdparty/recipeImplementation");
 var emailpassword_1 = require("./emailpassword");
 var thirdparty_1 = require("./thirdparty");
-function getRecipeImplementation(recipeId, appInfo) {
-    var emailPasswordImpl = (0, recipeImplementation_1.default)(recipeId, appInfo);
-    var thirdPartyImpl = (0, recipeImplementation_2.default)(recipeId, appInfo);
+function getRecipeImplementation(recipeId, appInfo, preAPIHook, postAPIHook) {
+    var emailPasswordImpl = (0, recipeImplementation_1.default)(recipeId, appInfo, preAPIHook, postAPIHook);
+    var thirdPartyImpl = (0, recipeImplementation_2.default)(recipeId, appInfo, preAPIHook, postAPIHook);
     return {
         submitNewPassword: function (input) {
             return __awaiter(this, void 0, void 0, function () {

--- a/lib/build/recipe/thirdpartyemailpassword/types.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/types.d.ts
@@ -1,13 +1,6 @@
-import {
-    PreAndPostAPIHookAction as EmailPasswordPreAndPostAPIHookAction,
-    NormalisedInputType as NormalisedEmailPasswordConfig,
-} from "../emailpassword/types";
+import { PreAndPostAPIHookAction as EmailPasswordPreAndPostAPIHookAction } from "../emailpassword/types";
 import { RecipePostAPIHookContext, RecipePreAPIHookContext } from "../recipeModule/types";
-import {
-    PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction,
-    StateObject,
-    NormalisedInputType as NormalisedThirdPartyConfig,
-} from "../thirdparty/types";
+import { PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction, StateObject } from "../thirdparty/types";
 import { RecipeFunctionOptions } from "../recipeModule/types";
 import {
     UserType,
@@ -42,7 +35,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -64,7 +56,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -81,12 +72,7 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
     >;
-    doesEmailExist: (input: {
-        email: string;
-        config: NormalisedEmailPasswordConfig;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    doesEmailExist: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
@@ -96,7 +82,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -119,7 +104,6 @@ export declare type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -141,10 +125,9 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
     >;
-    getResetPasswordTokenFromURL: (input: { config: NormalisedEmailPasswordConfig; userContext: any }) => string;
+    getResetPasswordTokenFromURL: (input: { userContext: any }) => string;
     getAuthorisationURLFromBackend: (input: {
         providerId: string;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
         options?: RecipeFunctionOptions;
     }) => Promise<{
@@ -152,11 +135,7 @@ export declare type RecipeInterface = {
         url: string;
         fetchResponse: Response;
     }>;
-    thirdPartySignInAndUp: (input: {
-        config: NormalisedThirdPartyConfig;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<
+    thirdPartySignInAndUp: (input: { userContext: any; options?: RecipeFunctionOptions }) => Promise<
         | {
               status: "OK";
               user: UserType;
@@ -170,29 +149,25 @@ export declare type RecipeInterface = {
     >;
     getStateAndOtherInfoFromStorage: <CustomStateProperties>(input: {
         userContext: any;
-        config: NormalisedThirdPartyConfig;
     }) => (StateObject & CustomStateProperties) | undefined;
     setStateAndOtherInfoToStorage: <CustomStateProperties>(input: {
         state: StateObject & CustomStateProperties;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
     }) => void;
     getAuthorizationURLWithQueryParamsAndSetState: (input: {
         providerId: string;
         authorisationURL: string;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
         providerClientId?: string;
         options?: RecipeFunctionOptions;
     }) => Promise<string>;
-    generateStateToSendToOAuthProvider: (input: { userContext: any; config: NormalisedThirdPartyConfig }) => string;
+    generateStateToSendToOAuthProvider: (input: { userContext: any }) => string;
     verifyAndGetStateOrThrowError: <CustomStateProperties>(input: {
         stateFromAuthProvider: string | undefined;
         stateObjectFromStorage: (StateObject & CustomStateProperties) | undefined;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
     }) => Promise<StateObject & CustomStateProperties>;
-    getAuthCodeFromURL: (input: { config: NormalisedThirdPartyConfig; userContext: any }) => string;
-    getAuthErrorFromURL: (input: { config: NormalisedThirdPartyConfig; userContext: any }) => string | undefined;
-    getAuthStateFromURL: (input: { config: NormalisedThirdPartyConfig; userContext: any }) => string;
+    getAuthCodeFromURL: (input: { userContext: any }) => string;
+    getAuthErrorFromURL: (input: { userContext: any }) => string | undefined;
+    getAuthStateFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/ts/querier.ts
+++ b/lib/ts/querier.ts
@@ -16,10 +16,11 @@ import NormalisedURLPath from "./normalisedURLPath";
 import { supported_fdi } from "./version";
 import { NormalisedAppInfo } from "./types";
 import {
-    NormalisedRecipeConfig,
     PostAPIHookFunction,
     PreAPIHookFunction,
     RecipeFunctionOptions,
+    RecipePostAPIHookFunction,
+    RecipePreAPIHookFunction,
 } from "./recipe/recipeModule/types";
 import STGeneralError from "./error";
 
@@ -247,18 +248,18 @@ export default class Querier {
     };
 
     static preparePreAPIHook = <Action>({
-        config,
+        recipePreAPIHook,
         action,
         options,
         userContext,
     }: {
-        config: NormalisedRecipeConfig<Action>;
+        recipePreAPIHook: RecipePreAPIHookFunction<Action>;
         action: Action;
         options?: RecipeFunctionOptions;
         userContext: any;
     }): PreAPIHookFunction => {
         return async (context): Promise<{ url: string; requestInit: RequestInit }> => {
-            let postRecipeHookContext = await config.preAPIHook({
+            let postRecipeHookContext = await recipePreAPIHook({
                 ...context,
                 action,
                 userContext,
@@ -277,16 +278,16 @@ export default class Querier {
     };
 
     static preparePostAPIHook = <Action>({
-        config,
+        recipePostAPIHook,
         action,
         userContext,
     }: {
-        config: NormalisedRecipeConfig<Action>;
+        recipePostAPIHook: RecipePostAPIHookFunction<Action>;
         action: Action;
         userContext: any;
     }): PostAPIHookFunction => {
         return async (context) => {
-            await config.postAPIHook({
+            await recipePostAPIHook({
                 ...context,
                 userContext,
                 action,

--- a/lib/ts/recipe/emailpassword/index.ts
+++ b/lib/ts/recipe/emailpassword/index.ts
@@ -44,11 +44,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.submitNewPassword({
+        return Recipe.getInstanceOrThrow().recipeImplementation.submitNewPassword({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -74,11 +71,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.sendPasswordResetEmail({
+        return Recipe.getInstanceOrThrow().recipeImplementation.sendPasswordResetEmail({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -105,11 +99,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.signUp({
+        return Recipe.getInstanceOrThrow().recipeImplementation.signUp({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -140,11 +131,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.signIn({
+        return Recipe.getInstanceOrThrow().recipeImplementation.signIn({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -154,52 +142,40 @@ export default class RecipeWrapper {
         doesExist: boolean;
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.doesEmailExist({
+        return Recipe.getInstanceOrThrow().recipeImplementation.doesEmailExist({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
 
-    static async verifyEmail(input: { token?: string; options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async verifyEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.verifyEmail({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.verifyEmail({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async sendVerificationEmail(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async sendVerificationEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.sendVerificationEmail({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.sendVerificationEmail({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async isEmailVerified(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async isEmailVerified(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.isEmailVerified({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.isEmailVerified({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 }

--- a/lib/ts/recipe/emailpassword/recipe.ts
+++ b/lib/ts/recipe/emailpassword/recipe.ts
@@ -31,7 +31,14 @@ export default class Recipe extends AuthRecipeWithEmailVerification<PreAndPostAP
     constructor(config: InputType, recipes: { emailVerification: EmailVerificationRecipe | undefined }) {
         super(normaliseUserInput(config), recipes);
 
-        const builder = new OverrideableBuilder(RecipeImplementation(this.config.recipeId, this.config.appInfo));
+        const builder = new OverrideableBuilder(
+            RecipeImplementation(
+                this.config.recipeId,
+                this.config.appInfo,
+                this.config.preAPIHook,
+                this.config.postAPIHook
+            )
+        );
         this.recipeImplementation = builder.override(this.config.override.functions).build();
     }
 

--- a/lib/ts/recipe/emailpassword/recipeImplementation.ts
+++ b/lib/ts/recipe/emailpassword/recipeImplementation.ts
@@ -13,19 +13,22 @@
  * under the License.
  */
 import Querier from "../../querier";
-import { RecipeInterface } from "./types";
-import { NormalisedAppInfo } from "../../types";
+import { PreAndPostAPIHookAction, RecipeInterface } from "./types";
 import { getQueryParams } from "../../utils";
-import { RecipeFunctionOptions } from "../recipeModule/types";
-import { NormalisedInputType } from "./types";
+import { RecipeFunctionOptions, RecipePostAPIHookFunction, RecipePreAPIHookFunction } from "../recipeModule/types";
 import { UserType } from ".";
+import { NormalisedAppInfo } from "../../types";
 
-export default function getRecipeImplementation(recipeId: string, appInfo: NormalisedAppInfo): RecipeInterface {
+export default function getRecipeImplementation(
+    recipeId: string,
+    appInfo: NormalisedAppInfo,
+    preAPIHook: RecipePreAPIHookFunction<PreAndPostAPIHookAction>,
+    postAPIHook: RecipePostAPIHookFunction<PreAndPostAPIHookAction>
+): RecipeInterface {
     const querier = new Querier(recipeId, appInfo);
     return {
         submitNewPassword: async function ({
             formFields,
-            config,
             options,
             userContext,
         }: {
@@ -33,7 +36,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 id: string;
                 value: string;
             }[];
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<
@@ -51,7 +53,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
               }
         > {
             const token = this.getResetPasswordTokenFromURL({
-                config,
                 userContext,
             });
 
@@ -70,13 +71,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 "/user/password/reset",
                 { body: JSON.stringify({ formFields, token, method: "token" }) },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "SUBMIT_NEW_PASSWORD",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     action: "SUBMIT_NEW_PASSWORD",
                     userContext,
                 })
@@ -98,7 +99,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
 
         sendPasswordResetEmail: async function ({
             formFields,
-            config,
             options,
             userContext,
         }: {
@@ -106,7 +106,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 id: string;
                 value: string;
             }[];
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<
@@ -138,13 +137,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 "/user/password/reset/token",
                 { body: JSON.stringify({ formFields }) },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "SEND_RESET_PASSWORD_EMAIL",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     action: "SEND_RESET_PASSWORD_EMAIL",
                     userContext,
                 })
@@ -166,7 +165,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
 
         signUp: async function ({
             formFields,
-            config,
             options,
             userContext,
         }: {
@@ -174,7 +172,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 id: string;
                 value: string;
             }[];
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<
@@ -208,13 +205,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 "/signup",
                 { body: JSON.stringify({ formFields }) },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "EMAIL_PASSWORD_SIGN_UP",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     action: "EMAIL_PASSWORD_SIGN_UP",
                     userContext,
                 })
@@ -237,7 +234,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
 
         signIn: async function ({
             formFields,
-            config,
             options,
             userContext,
         }: {
@@ -245,7 +241,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 id: string;
                 value: string;
             }[];
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<
@@ -286,13 +281,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 "/signin",
                 { body: JSON.stringify({ formFields }) },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "EMAIL_PASSWORD_SIGN_IN",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     action: "EMAIL_PASSWORD_SIGN_IN",
                     userContext,
                 })
@@ -322,12 +317,10 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
 
         doesEmailExist: async function ({
             email,
-            config,
             options,
             userContext,
         }: {
             email: string;
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<{
@@ -343,13 +336,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 {},
                 { email },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "EMAIL_EXISTS",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     action: "EMAIL_EXISTS",
                     userContext,
                 })

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -58,7 +58,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -81,7 +80,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -104,7 +102,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -128,7 +125,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedInputType;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -151,16 +147,11 @@ export type RecipeInterface = {
           }
     >;
 
-    doesEmailExist: (input: {
-        email: string;
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    doesEmailExist: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
     }>;
 
-    getResetPasswordTokenFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getResetPasswordTokenFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/ts/recipe/emailverification/index.ts
+++ b/lib/ts/recipe/emailverification/index.ts
@@ -22,43 +22,34 @@ export default class RecipeWrapper {
         return Recipe.init(config);
     }
 
-    static verifyEmail(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static verifyEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.verifyEmail({
-            options: input.options,
-            config: recipeInstance.config,
-            userContext: getNormalisedUserContext(input.userContext),
+        return Recipe.getInstanceOrThrow().recipeImplementation.verifyEmail({
+            ...input,
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static sendVerificationEmail(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static sendVerificationEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.sendVerificationEmail({
-            options: input.options,
-            config: recipeInstance.config,
-            userContext: getNormalisedUserContext(input.userContext),
+        return Recipe.getInstanceOrThrow().recipeImplementation.sendVerificationEmail({
+            ...input,
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static isEmailVerified(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static isEmailVerified(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.isEmailVerified({
-            options: input.options,
-            config: recipeInstance.config,
-            userContext: getNormalisedUserContext(input.userContext),
+        return Recipe.getInstanceOrThrow().recipeImplementation.isEmailVerified({
+            ...input,
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 }

--- a/lib/ts/recipe/emailverification/recipe.ts
+++ b/lib/ts/recipe/emailverification/recipe.ts
@@ -30,7 +30,14 @@ export default class Recipe implements RecipeModule<PreAndPostAPIHookAction, Nor
 
     constructor(config: InputType) {
         this.config = normaliseUserInput(config);
-        const builder = new OverrideableBuilder(RecipeImplementation(this.config.recipeId, this.config.appInfo));
+        const builder = new OverrideableBuilder(
+            RecipeImplementation(
+                this.config.recipeId,
+                this.config.appInfo,
+                this.config.preAPIHook,
+                this.config.postAPIHook
+            )
+        );
         this.recipeImplementation = builder.override(this.config.override.functions).build();
     }
 

--- a/lib/ts/recipe/emailverification/recipeImplementation.ts
+++ b/lib/ts/recipe/emailverification/recipeImplementation.ts
@@ -15,18 +15,21 @@
 import Querier from "../../querier";
 import { NormalisedAppInfo } from "../../types";
 import { getQueryParams } from "../../utils";
-import { RecipeFunctionOptions } from "../recipeModule/types";
-import { NormalisedInputType, RecipeInterface } from "./types";
+import { RecipeFunctionOptions, RecipePostAPIHookFunction, RecipePreAPIHookFunction } from "../recipeModule/types";
+import { PreAndPostAPIHookAction, RecipeInterface } from "./types";
 
-export default function getRecipeImplementation(recipeId: string, appInfo: NormalisedAppInfo): RecipeInterface {
+export default function getRecipeImplementation(
+    recipeId: string,
+    appInfo: NormalisedAppInfo,
+    preAPIHook: RecipePreAPIHookFunction<PreAndPostAPIHookAction>,
+    postAPIHook: RecipePostAPIHookFunction<PreAndPostAPIHookAction>
+): RecipeInterface {
     const querier = new Querier(recipeId, appInfo);
     return {
         verifyEmail: async function ({
-            config,
             options,
             userContext,
         }: {
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<{
@@ -34,7 +37,6 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
             fetchResponse: Response;
         }> {
             const token = this.getEmailVerificationTokenFromURL({
-                config,
                 userContext,
             });
 
@@ -49,13 +51,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                     }),
                 },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "VERIFY_EMAIL",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     userContext,
                     action: "VERIFY_EMAIL",
                 })
@@ -68,11 +70,9 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
         },
 
         isEmailVerified: async function ({
-            config,
             options,
             userContext,
         }: {
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<{
@@ -85,13 +85,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 {},
                 undefined,
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "IS_EMAIL_VERIFIED",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     userContext,
                     action: "IS_EMAIL_VERIFIED",
                 })
@@ -105,11 +105,9 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
         },
 
         sendVerificationEmail: async function ({
-            config,
             options,
             userContext,
         }: {
-            config: NormalisedInputType;
             options?: RecipeFunctionOptions;
             userContext: any;
         }): Promise<{
@@ -120,13 +118,13 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 "/user/email/verify/token",
                 { body: JSON.stringify({}) },
                 Querier.preparePreAPIHook({
-                    config,
+                    recipePreAPIHook: preAPIHook,
                     action: "SEND_VERIFY_EMAIL",
                     options,
                     userContext,
                 }),
                 Querier.preparePostAPIHook({
-                    config,
+                    recipePostAPIHook: postAPIHook,
                     userContext,
                     action: "SEND_VERIFY_EMAIL",
                 })

--- a/lib/ts/recipe/emailverification/types.ts
+++ b/lib/ts/recipe/emailverification/types.ts
@@ -46,33 +46,21 @@ export type NormalisedInputType = NormalisedRecipeConfig<PreAndPostAPIHookAction
 };
 
 export type RecipeInterface = {
-    verifyEmail: (input: {
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    verifyEmail: (input: { options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
 
-    sendVerificationEmail: (input: {
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    sendVerificationEmail: (input: { options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
 
-    isEmailVerified: (input: {
-        config: NormalisedInputType;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    isEmailVerified: (input: { options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }>;
 
-    getEmailVerificationTokenFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getEmailVerificationTokenFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/ts/recipe/recipeModule/types.ts
+++ b/lib/ts/recipe/recipeModule/types.ts
@@ -40,18 +40,24 @@ export type PostAPIHookFunction = (context: {
     fetchResponse: Response;
 }) => Promise<void>;
 
+export type RecipePreAPIHookFunction<Action> = (
+    context: RecipePreAPIHookContext<Action>
+) => Promise<{ url: string; requestInit: RequestInit }>;
+
+export type RecipePostAPIHookFunction<Action> = (context: RecipePostAPIHookContext<Action>) => Promise<void>;
+
 export type RecipeConfig<Action> = {
     recipeId: string;
     appInfo: NormalisedAppInfo;
-    preAPIHook?: (context: RecipePreAPIHookContext<Action>) => Promise<{ url: string; requestInit: RequestInit }>;
-    postAPIHook?: (context: RecipePostAPIHookContext<Action>) => Promise<void>;
+    preAPIHook?: RecipePreAPIHookFunction<Action>;
+    postAPIHook?: RecipePostAPIHookFunction<Action>;
 };
 
 export type NormalisedRecipeConfig<Action> = {
     recipeId: string;
     appInfo: NormalisedAppInfo;
-    preAPIHook: (context: RecipePreAPIHookContext<Action>) => Promise<{ url: string; requestInit: RequestInit }>;
-    postAPIHook: (context: RecipePostAPIHookContext<Action>) => Promise<void>;
+    preAPIHook: RecipePreAPIHookFunction<Action>;
+    postAPIHook: RecipePostAPIHookFunction<Action>;
 };
 
 /**

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -38,11 +38,8 @@ export default class RecipeWrapper {
         userContext?: any;
         options?: RecipeFunctionOptions;
     }): Promise<string> {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState({
+        return Recipe.getInstanceOrThrow().recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -59,52 +56,40 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.signInAndUp({
+        return Recipe.getInstanceOrThrow().recipeImplementation.signInAndUp({
             ...input,
-            config: recipeInstance.config,
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async verifyEmail(input: { token?: string; options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async verifyEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.verifyEmail({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.verifyEmail({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async sendVerificationEmail(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async sendVerificationEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.sendVerificationEmail({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.sendVerificationEmail({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async isEmailVerified(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async isEmailVerified(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.isEmailVerified({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.isEmailVerified({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 }

--- a/lib/ts/recipe/thirdparty/recipe.ts
+++ b/lib/ts/recipe/thirdparty/recipe.ts
@@ -31,7 +31,14 @@ export default class Recipe extends AuthRecipeWithEmailVerification<PreAndPostAP
     constructor(config: InputType, recipes: { emailVerification: EmailVerificationRecipe | undefined }) {
         super(normaliseUserInput(config), recipes);
 
-        const builder = new OverrideableBuilder(RecipeImplementation(this.config.recipeId, this.config.appInfo));
+        const builder = new OverrideableBuilder(
+            RecipeImplementation(
+                this.config.recipeId,
+                this.config.appInfo,
+                this.config.preAPIHook,
+                this.config.postAPIHook
+            )
+        );
         this.recipeImplementation = builder.override(this.config.override.functions).build();
     }
 

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -56,19 +56,16 @@ export type StateObject = {
 export type RecipeInterface = {
     getStateAndOtherInfoFromStorage: <CustomStateProperties>(input: {
         userContext: any;
-        config: NormalisedInputType;
     }) => (StateObject & CustomStateProperties) | undefined;
 
     setStateAndOtherInfoToStorage: <CustomStateProperties>(input: {
         state: StateObject & CustomStateProperties;
-        config: NormalisedInputType;
         userContext: any;
     }) => void;
 
     getAuthorizationURLWithQueryParamsAndSetState: (input: {
         providerId: string;
         authorisationURL: string;
-        config: NormalisedInputType;
         userContext: any;
         providerClientId?: string;
         options?: RecipeFunctionOptions;
@@ -76,7 +73,6 @@ export type RecipeInterface = {
 
     getAuthorisationURLFromBackend: (input: {
         providerId: string;
-        config: NormalisedInputType;
         userContext: any;
         options?: RecipeFunctionOptions;
     }) => Promise<{
@@ -85,7 +81,7 @@ export type RecipeInterface = {
         fetchResponse: Response;
     }>;
 
-    signInAndUp: (input: { config: NormalisedInputType; userContext: any; options?: RecipeFunctionOptions }) => Promise<
+    signInAndUp: (input: { userContext: any; options?: RecipeFunctionOptions }) => Promise<
         | {
               status: "OK";
               user: UserType;
@@ -98,18 +94,17 @@ export type RecipeInterface = {
           }
     >;
 
-    generateStateToSendToOAuthProvider: (input: { userContext: any; config: NormalisedInputType }) => string;
+    generateStateToSendToOAuthProvider: (input: { userContext: any }) => string;
 
     verifyAndGetStateOrThrowError: <CustomStateProperties>(input: {
         stateFromAuthProvider: string | undefined;
         stateObjectFromStorage: (StateObject & CustomStateProperties) | undefined;
-        config: NormalisedInputType;
         userContext: any;
     }) => Promise<StateObject & CustomStateProperties>;
 
-    getAuthCodeFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getAuthCodeFromURL: (input: { userContext: any }) => string;
 
-    getAuthErrorFromURL: (input: { config: NormalisedInputType; userContext: any }) => string | undefined;
+    getAuthErrorFromURL: (input: { userContext: any }) => string | undefined;
 
-    getAuthStateFromURL: (input: { config: NormalisedInputType; userContext: any }) => string;
+    getAuthStateFromURL: (input: { userContext: any }) => string;
 };

--- a/lib/ts/recipe/thirdpartyemailpassword/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/index.ts
@@ -45,11 +45,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.submitNewPassword({
+        return Recipe.getInstanceOrThrow().recipeImplementation.submitNewPassword({
             ...input,
-            config: recipeInstance.emailPasswordRecipe.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -75,11 +72,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.sendPasswordResetEmail({
+        return Recipe.getInstanceOrThrow().recipeImplementation.sendPasswordResetEmail({
             ...input,
-            config: recipeInstance.emailPasswordRecipe.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -89,11 +83,8 @@ export default class RecipeWrapper {
         doesExist: boolean;
         fetchResponse: Response;
     }> {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.doesEmailExist({
+        return Recipe.getInstanceOrThrow().recipeImplementation.doesEmailExist({
             ...input,
-            config: recipeInstance.emailPasswordRecipe.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -120,11 +111,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.emailPasswordSignUp({
+        return Recipe.getInstanceOrThrow().recipeImplementation.emailPasswordSignUp({
             ...input,
-            config: recipeInstance.emailPasswordRecipe.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -155,11 +143,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.emailPasswordSignIn({
+        return Recipe.getInstanceOrThrow().recipeImplementation.emailPasswordSignIn({
             ...input,
-            config: recipeInstance.emailPasswordRecipe.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
@@ -176,11 +161,8 @@ export default class RecipeWrapper {
               fetchResponse: Response;
           }
     > {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.thirdPartySignInAndUp({
+        return Recipe.getInstanceOrThrow().recipeImplementation.thirdPartySignInAndUp({
             ...input,
-            config: recipeInstance.thirdPartyRecipe.config,
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
@@ -192,52 +174,40 @@ export default class RecipeWrapper {
         providerClientId?: string;
         options?: RecipeFunctionOptions;
     }): Promise<string> {
-        const recipeInstance = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState({
+        return Recipe.getInstanceOrThrow().recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState({
             ...input,
-            config: recipeInstance.thirdPartyRecipe.config,
             userContext: getNormalisedUserContext(input.userContext),
         });
     }
 
-    static async verifyEmail(input: { token?: string; options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async verifyEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.verifyEmail({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.verifyEmail({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async sendVerificationEmail(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async sendVerificationEmail(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.sendVerificationEmail({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.sendVerificationEmail({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async isEmailVerified(input: { options?: RecipeFunctionOptions; userContext: any }): Promise<{
+    static async isEmailVerified(input?: { options?: RecipeFunctionOptions; userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }> {
-        let recipeInstance: Recipe = Recipe.getInstanceOrThrow();
-
-        return recipeInstance.emailVerificationRecipe.recipeImplementation.isEmailVerified({
+        return Recipe.getInstanceOrThrow().emailVerificationRecipe.recipeImplementation.isEmailVerified({
             ...input,
-            config: recipeInstance.emailVerificationRecipe.config,
-            userContext: getNormalisedUserContext(input.userContext),
+            userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 }

--- a/lib/ts/recipe/thirdpartyemailpassword/recipe.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipe.ts
@@ -43,7 +43,14 @@ export default class Recipe extends AuthRecipeWithEmailVerification<PreAndPostAP
     ) {
         super(normaliseUserInput(config), recipes);
 
-        const builder = new OverrideableBuilder(RecipeImplementation(this.config.recipeId, this.config.appInfo));
+        const builder = new OverrideableBuilder(
+            RecipeImplementation(
+                this.config.recipeId,
+                this.config.appInfo,
+                this.config.preAPIHook,
+                this.config.postAPIHook
+            )
+        );
         const _recipeImplementation = builder.override(this.config.override.functions).build();
         this.recipeImplementation = _recipeImplementation;
 

--- a/lib/ts/recipe/thirdpartyemailpassword/types.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/types.ts
@@ -12,16 +12,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import {
-    PreAndPostAPIHookAction as EmailPasswordPreAndPostAPIHookAction,
-    NormalisedInputType as NormalisedEmailPasswordConfig,
-} from "../emailpassword/types";
+import { PreAndPostAPIHookAction as EmailPasswordPreAndPostAPIHookAction } from "../emailpassword/types";
 import { RecipePostAPIHookContext, RecipePreAPIHookContext } from "../recipeModule/types";
-import {
-    PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction,
-    StateObject,
-    NormalisedInputType as NormalisedThirdPartyConfig,
-} from "../thirdparty/types";
+import { PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction, StateObject } from "../thirdparty/types";
 import { RecipeFunctionOptions } from "../recipeModule/types";
 import {
     UserType,
@@ -61,7 +54,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -84,7 +76,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -102,12 +93,7 @@ export type RecipeInterface = {
           }
     >;
 
-    doesEmailExist: (input: {
-        email: string;
-        config: NormalisedEmailPasswordConfig;
-        options?: RecipeFunctionOptions;
-        userContext: any;
-    }) => Promise<{
+    doesEmailExist: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
@@ -118,7 +104,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -142,7 +127,6 @@ export type RecipeInterface = {
             id: string;
             value: string;
         }[];
-        config: NormalisedEmailPasswordConfig;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -165,11 +149,10 @@ export type RecipeInterface = {
           }
     >;
 
-    getResetPasswordTokenFromURL: (input: { config: NormalisedEmailPasswordConfig; userContext: any }) => string;
+    getResetPasswordTokenFromURL: (input: { userContext: any }) => string;
 
     getAuthorisationURLFromBackend: (input: {
         providerId: string;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
         options?: RecipeFunctionOptions;
     }) => Promise<{
@@ -178,11 +161,7 @@ export type RecipeInterface = {
         fetchResponse: Response;
     }>;
 
-    thirdPartySignInAndUp: (input: {
-        config: NormalisedThirdPartyConfig;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<
+    thirdPartySignInAndUp: (input: { userContext: any; options?: RecipeFunctionOptions }) => Promise<
         | {
               status: "OK";
               user: UserType;
@@ -197,36 +176,32 @@ export type RecipeInterface = {
 
     getStateAndOtherInfoFromStorage: <CustomStateProperties>(input: {
         userContext: any;
-        config: NormalisedThirdPartyConfig;
     }) => (StateObject & CustomStateProperties) | undefined;
 
     setStateAndOtherInfoToStorage: <CustomStateProperties>(input: {
         state: StateObject & CustomStateProperties;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
     }) => void;
 
     getAuthorizationURLWithQueryParamsAndSetState: (input: {
         providerId: string;
         authorisationURL: string;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
         providerClientId?: string;
         options?: RecipeFunctionOptions;
     }) => Promise<string>;
 
-    generateStateToSendToOAuthProvider: (input: { userContext: any; config: NormalisedThirdPartyConfig }) => string;
+    generateStateToSendToOAuthProvider: (input: { userContext: any }) => string;
 
     verifyAndGetStateOrThrowError: <CustomStateProperties>(input: {
         stateFromAuthProvider: string | undefined;
         stateObjectFromStorage: (StateObject & CustomStateProperties) | undefined;
-        config: NormalisedThirdPartyConfig;
         userContext: any;
     }) => Promise<StateObject & CustomStateProperties>;
 
-    getAuthCodeFromURL: (input: { config: NormalisedThirdPartyConfig; userContext: any }) => string;
+    getAuthCodeFromURL: (input: { userContext: any }) => string;
 
-    getAuthErrorFromURL: (input: { config: NormalisedThirdPartyConfig; userContext: any }) => string | undefined;
+    getAuthErrorFromURL: (input: { userContext: any }) => string | undefined;
 
-    getAuthStateFromURL: (input: { config: NormalisedThirdPartyConfig; userContext: any }) => string;
+    getAuthStateFromURL: (input: { userContext: any }) => string;
 };


### PR DESCRIPTION
## Summary
- To make it easy to create the recipe implementations from other SDKs, the recipe function now accepts the required parameters as separate params rather than accepting the config directly

## Test plan
Integrated this version into auth-react and made sure all tests pass

## Remaining TODOs
- [ ] 