### PR TITLE
fix: Add common user input types to thirdpartypasswordless recipe user input type

### DIFF
--- a/lib/build/recipe/thirdpartypasswordless/types.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/types.d.ts
@@ -8,7 +8,12 @@ import {
     PasswordlessUser,
     PreAndPostAPIHookAction as PasswordlessPreAndPostAPIHookAction,
 } from "../passwordless/types";
-import { RecipeFunctionOptions, RecipePostAPIHookContext, RecipePreAPIHookContext } from "../recipeModule/types";
+import {
+    RecipeFunctionOptions,
+    RecipePostAPIHookContext,
+    RecipePreAPIHookContext,
+    UserInput as RecipeModuleUserInput,
+} from "../recipeModule/types";
 import { StateObject, PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction } from "../thirdparty/types";
 import { InputTypeOverride as EmailVerificationOverride } from "../emailverification/types";
 import OverrideableBuilder from "supertokens-js-override";
@@ -26,7 +31,7 @@ export declare type UserInput = {
             builder: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
     };
-};
+} & RecipeModuleUserInput<PreAndPostAPIHookAction>;
 export declare type InputType = AuthRecipeInputType<PreAndPostAPIHookAction> & UserInput;
 export declare type NormalisedInputType = AuthRecipeNormalisedInputType<PreAndPostAPIHookAction> & {
     override: {

--- a/lib/ts/recipe/thirdpartypasswordless/types.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/types.ts
@@ -23,7 +23,12 @@ import {
     PasswordlessUser,
     PreAndPostAPIHookAction as PasswordlessPreAndPostAPIHookAction,
 } from "../passwordless/types";
-import { RecipeFunctionOptions, RecipePostAPIHookContext, RecipePreAPIHookContext } from "../recipeModule/types";
+import {
+    RecipeFunctionOptions,
+    RecipePostAPIHookContext,
+    RecipePreAPIHookContext,
+    UserInput as RecipeModuleUserInput,
+} from "../recipeModule/types";
 import { StateObject, PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction } from "../thirdparty/types";
 import { InputTypeOverride as EmailVerificationOverride } from "../emailverification/types";
 import OverrideableBuilder from "supertokens-js-override";
@@ -44,7 +49,7 @@ export type UserInput = {
             builder: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
     };
-};
+} & RecipeModuleUserInput<PreAndPostAPIHookAction>;
 
 export type InputType = AuthRecipeInputType<PreAndPostAPIHookAction> & UserInput;
 


### PR DESCRIPTION
## Summary

- Adds the common recipe module input types to UserInput in ThirdPartyPasswordless. This includes the pre and post API hooks

## Remaining TODOs

- [ ] ...