### PR TITLE
refactor: Uses types from supertokens-website for session recipe

### DIFF
--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -1,7 +1,7 @@
-import { InputType, UserInput } from "./types";
+import { UserInput } from "./types";
 import { RecipeInterface } from "supertokens-website";
 export default class RecipeWrapper {
-    static init(config?: InputType): import("../../types").CreateRecipeFunction<unknown>;
+    static init(config?: UserInput): import("../../types").CreateRecipeFunction<unknown>;
     static getUserId(input?: { userContext?: any }): Promise<string>;
     static getAccessTokenPayloadSecurely(input?: { userContext?: any }): Promise<any>;
     static attemptRefreshingSession(): Promise<boolean>;

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -247,7 +247,6 @@ var Recipe = /** @class */ (function (_super) {
                         });
                     });
                 },
-                apiDomain: config.appInfo.apiDomain.getAsStringDangerous(),
                 apiBasePath: config.appInfo.apiBasePath.getAsStringDangerous(),
             })
         );
@@ -256,7 +255,11 @@ var Recipe = /** @class */ (function (_super) {
     Recipe.init = function (config) {
         return function (appInfo) {
             Recipe.instance = new Recipe(
-                __assign(__assign({}, config), { appInfo: appInfo, recipeId: Recipe.RECIPE_ID })
+                __assign(__assign({}, config), {
+                    appInfo: appInfo,
+                    recipeId: Recipe.RECIPE_ID,
+                    apiDomain: appInfo.apiDomain.getAsStringDangerous(),
+                })
             );
             return Recipe.instance;
         };

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -1,4 +1,4 @@
-import { InputType as STWebsiteInputType } from "supertokens-website";
+import { InputType as STWebsiteInputType, RecipeInterface as STWebsiteRecipeInterface } from "supertokens-website";
 import { NormalisedAppInfo } from "../../types";
 export declare type PreAndPostAPIHookAction = "SIGN_OUT" | "REFRESH_SESSION";
 export declare type RecipeEvent =
@@ -12,6 +12,7 @@ export declare type RecipeEvent =
           userContext: any;
       };
 export declare type UserInput = STWebsiteInputType;
+export declare type RecipeInterface = STWebsiteRecipeInterface;
 export declare type InputType = {
     recipeId: string;
     appInfo: NormalisedAppInfo;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -1,6 +1,5 @@
-import { RecipeInterface } from "supertokens-website";
+import { InputType as STWebsiteInputType } from "supertokens-website";
 import { NormalisedAppInfo } from "../../types";
-import OverrideableBuilder from "supertokens-js-override";
 export declare type PreAndPostAPIHookAction = "SIGN_OUT" | "REFRESH_SESSION";
 export declare type RecipeEvent =
     | {
@@ -12,36 +11,7 @@ export declare type RecipeEvent =
           sessionExpiredOrRevoked: boolean;
           userContext: any;
       };
-export declare type UserInput = {
-    apiDomain?: string;
-    apiBasePath?: string;
-    sessionScope?: string;
-    sessionExpiredStatusCode?: number;
-    autoAddCredentials?: boolean;
-    isInIframe?: boolean;
-    cookieDomain?: string;
-    preAPIHook?: (context: {
-        action: "SIGN_OUT" | "REFRESH_SESSION";
-        requestInit: RequestInit;
-        url: string;
-    }) => Promise<{
-        url: string;
-        requestInit: RequestInit;
-    }>;
-    postAPIHook?: (context: {
-        action: "SIGN_OUT" | "REFRESH_SESSION";
-        requestInit: RequestInit;
-        url: string;
-        fetchResponse: Response;
-    }) => Promise<void>;
-    onHandleEvent?: (event: RecipeEvent) => void;
-    override?: {
-        functions?: (
-            originalImplementation: RecipeInterface,
-            builder?: OverrideableBuilder<RecipeInterface>
-        ) => RecipeInterface;
-    };
-};
+export declare type UserInput = STWebsiteInputType;
 export declare type InputType = {
     recipeId: string;
     appInfo: NormalisedAppInfo;

--- a/lib/build/recipe/thirdpartypasswordless/types.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/types.d.ts
@@ -8,7 +8,12 @@ import {
     PasswordlessUser,
     PreAndPostAPIHookAction as PasswordlessPreAndPostAPIHookAction,
 } from "../passwordless/types";
-import { RecipeFunctionOptions, RecipePostAPIHookContext, RecipePreAPIHookContext } from "../recipeModule/types";
+import {
+    RecipeFunctionOptions,
+    RecipePostAPIHookContext,
+    RecipePreAPIHookContext,
+    UserInput as RecipeModuleUserInput,
+} from "../recipeModule/types";
 import { StateObject, PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction } from "../thirdparty/types";
 import { InputTypeOverride as EmailVerificationOverride } from "../emailverification/types";
 import OverrideableBuilder from "supertokens-js-override";
@@ -26,7 +31,7 @@ export declare type UserInput = {
             builder: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
     };
-};
+} & RecipeModuleUserInput<PreAndPostAPIHookAction>;
 export declare type InputType = AuthRecipeInputType<PreAndPostAPIHookAction> & UserInput;
 export declare type NormalisedInputType = AuthRecipeNormalisedInputType<PreAndPostAPIHookAction> & {
     override: {

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -14,11 +14,11 @@
  */
 import { getNormalisedUserContext } from "../../utils";
 import SessionRecipe from "./recipe";
-import { InputType, UserInput } from "./types";
+import { UserInput } from "./types";
 import { RecipeInterface } from "supertokens-website";
 
 export default class RecipeWrapper {
-    static init(config?: InputType) {
+    static init(config?: UserInput) {
         return SessionRecipe.init(config);
     }
 

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -44,7 +44,6 @@ export default class Recipe extends RecipeModule<unknown, any> {
                     return config.preAPIHook(context);
                 }
             },
-            apiDomain: config.appInfo.apiDomain.getAsStringDangerous(),
             apiBasePath: config.appInfo.apiBasePath.getAsStringDangerous(),
         });
     }
@@ -55,6 +54,7 @@ export default class Recipe extends RecipeModule<unknown, any> {
                 ...config,
                 appInfo,
                 recipeId: Recipe.RECIPE_ID,
+                apiDomain: appInfo.apiDomain.getAsStringDangerous(),
             });
 
             return Recipe.instance;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { InputType as STWebsiteInputType } from "supertokens-website";
+import { InputType as STWebsiteInputType, RecipeInterface as STWebsiteRecipeInterface } from "supertokens-website";
 import { NormalisedAppInfo } from "../../types";
 
 export type PreAndPostAPIHookAction = "SIGN_OUT" | "REFRESH_SESSION";
@@ -29,6 +29,7 @@ export type RecipeEvent =
       };
 
 export type UserInput = STWebsiteInputType;
+export type RecipeInterface = STWebsiteRecipeInterface;
 
 export type InputType = {
     recipeId: string;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -12,9 +12,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { RecipeInterface } from "supertokens-website";
+import { InputType as STWebsiteInputType } from "supertokens-website";
 import { NormalisedAppInfo } from "../../types";
-import OverrideableBuilder from "supertokens-js-override";
 
 export type PreAndPostAPIHookAction = "SIGN_OUT" | "REFRESH_SESSION";
 
@@ -29,33 +28,7 @@ export type RecipeEvent =
           userContext: any;
       };
 
-export type UserInput = {
-    apiDomain?: string;
-    apiBasePath?: string;
-    sessionScope?: string;
-    sessionExpiredStatusCode?: number;
-    autoAddCredentials?: boolean;
-    isInIframe?: boolean;
-    cookieDomain?: string;
-    preAPIHook?: (context: {
-        action: "SIGN_OUT" | "REFRESH_SESSION";
-        requestInit: RequestInit;
-        url: string;
-    }) => Promise<{ url: string; requestInit: RequestInit }>;
-    postAPIHook?: (context: {
-        action: "SIGN_OUT" | "REFRESH_SESSION";
-        requestInit: RequestInit;
-        url: string;
-        fetchResponse: Response;
-    }) => Promise<void>;
-    onHandleEvent?: (event: RecipeEvent) => void;
-    override?: {
-        functions?: (
-            originalImplementation: RecipeInterface,
-            builder?: OverrideableBuilder<RecipeInterface>
-        ) => RecipeInterface;
-    };
-};
+export type UserInput = STWebsiteInputType;
 
 export type InputType = {
     recipeId: string;

--- a/lib/ts/recipe/thirdpartypasswordless/types.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/types.ts
@@ -23,7 +23,12 @@ import {
     PasswordlessUser,
     PreAndPostAPIHookAction as PasswordlessPreAndPostAPIHookAction,
 } from "../passwordless/types";
-import { RecipeFunctionOptions, RecipePostAPIHookContext, RecipePreAPIHookContext } from "../recipeModule/types";
+import {
+    RecipeFunctionOptions,
+    RecipePostAPIHookContext,
+    RecipePreAPIHookContext,
+    UserInput as RecipeModuleUserInput,
+} from "../recipeModule/types";
 import { StateObject, PreAndPostAPIHookAction as ThirdPartyPreAndPostAPIHookAction } from "../thirdparty/types";
 import { InputTypeOverride as EmailVerificationOverride } from "../emailverification/types";
 import OverrideableBuilder from "supertokens-js-override";
@@ -44,7 +49,7 @@ export type UserInput = {
             builder: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
     };
-};
+} & RecipeModuleUserInput<PreAndPostAPIHookAction>;
 
 export type InputType = AuthRecipeInputType<PreAndPostAPIHookAction> & UserInput;
 


### PR DESCRIPTION
## Summary
- Uses input type from supertokens-website instead of redeclaring it

## Related PRs (These should be merged before this one)
- https://github.com/supertokens/supertokens-web-js/pull/23

## Remaining TODOs
- [x] Verify size-limit