### PR TITLE
feat: Add wrappers around webauthn methods to handle native API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.15.0] - 2024-12-10
 
 -   Added webauthn support for various functionalities
+-   Adds wrapper methods by using webauthn to provide ease of usage for passkeys
 
 ## [0.14.0] - 2024-10-07
 

--- a/lib/build/recipe/webauthn/index.d.ts
+++ b/lib/build/recipe/webauthn/index.d.ts
@@ -1,3 +1,4 @@
+import { AuthenticationResponseJSON, RegistrationResponseJSON } from "@simplewebauthn/browser";
 import { GeneralErrorResponse, User } from "../../types";
 import { RecipeFunctionOptions } from "../recipeModule/types";
 import { CredentialPayload, ResidentKey, UserInput, UserVerification } from "./types";
@@ -120,7 +121,7 @@ export default class RecipeWrapper {
      */
     static signUp(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }): Promise<
@@ -165,7 +166,7 @@ export default class RecipeWrapper {
      */
     static signIn(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }): Promise<
@@ -270,6 +271,157 @@ export default class RecipeWrapper {
               reason: string;
           }
     >;
+    /**
+     * Register the new device and signup the user with the passed email ID.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param email Email of the user to register and signup
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    static registerAndSignUp(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_EMAIL_ERROR";
+              err: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | {
+              status: "SIGN_UP_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "GENERATED_OPTIONS_NOT_FOUND_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_AUTHENTICATOR_ERROR";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "EMAIL_ALREADY_EXISTS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "AUTHENTICATOR_ALREADY_REGISTERED";
+          }
+    >;
+    /**
+     * Authenticate the user and sign them in after verifying their identity.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param email Email of the user to authenticate and signin
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    static authenticateAndSignIn(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "SIGN_IN_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+    >;
+    /**
+     * Register the new device and recover the user's account with the recover token.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param recoverAccountToken Recovery token for the user's account
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    static registerAndRecoverAccount(input: {
+        recoverAccountToken: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }): Promise<
+        | {
+              status: "OK";
+              user: User;
+              email: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | {
+              status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "GENERATED_OPTIONS_NOT_FOUND_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_AUTHENTICATOR_ERROR";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "AUTHENTICATOR_ALREADY_REGISTERED";
+          }
+    >;
 }
 declare const init: typeof RecipeWrapper.init;
 declare const registerOptions: typeof RecipeWrapper.registerOptions;
@@ -279,6 +431,9 @@ declare const signIn: typeof RecipeWrapper.signIn;
 declare const emailExists: typeof RecipeWrapper.emailExists;
 declare const generateRecoverAccountToken: typeof RecipeWrapper.generateRecoverAccountToken;
 declare const recoverAccount: typeof RecipeWrapper.recoverAccount;
+declare const registerAndSignup: typeof RecipeWrapper.registerAndSignUp;
+declare const authenticateAndSignIn: typeof RecipeWrapper.authenticateAndSignIn;
+declare const registerAndRecoverAccount: typeof RecipeWrapper.registerAndRecoverAccount;
 export {
     init,
     registerOptions,
@@ -288,4 +443,7 @@ export {
     emailExists,
     generateRecoverAccountToken,
     recoverAccount,
+    registerAndSignup,
+    authenticateAndSignIn,
+    registerAndRecoverAccount,
 };

--- a/lib/build/recipe/webauthn/index.d.ts
+++ b/lib/build/recipe/webauthn/index.d.ts
@@ -1,7 +1,15 @@
 import { AuthenticationResponseJSON, RegistrationResponseJSON } from "@simplewebauthn/browser";
 import { GeneralErrorResponse, User } from "../../types";
 import { RecipeFunctionOptions } from "../recipeModule/types";
-import { CredentialPayload, ResidentKey, UserInput, UserVerification } from "./types";
+import {
+    CredentialPayload,
+    ResidentKey,
+    UserInput,
+    UserVerification,
+    RegistrationOptions,
+    AuthenticationOptions,
+    RecipeInterface,
+} from "./types";
 export default class RecipeWrapper {
     static init(
         config?: UserInput
@@ -20,7 +28,7 @@ export default class RecipeWrapper {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the created webauthn details (challenge, etc.)
      */
-    static registerOptions(
+    static getRegisterOptions(
         input: {
             options?: RecipeFunctionOptions;
             userContext: any;
@@ -90,7 +98,7 @@ export default class RecipeWrapper {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the webauthn options (challenge, etc.)
      */
-    static signInOptions(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+    static getSignInOptions(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
         | {
               status: "OK";
               webauthnGeneratedOptionsId: string;
@@ -194,7 +202,7 @@ export default class RecipeWrapper {
      *
      * @returns `{ status: "OK", ...}` if successful along with a boolean indicating existence
      */
-    static emailExists(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+    static getEmailExists(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
         | {
               status: "OK";
               exists: boolean;
@@ -272,6 +280,47 @@ export default class RecipeWrapper {
           }
     >;
     /**
+     * Register credential with the passed options by using native webauthn functions.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param registrationOptions Options to pass for the registration.
+     *
+     * @returns `{ status: "OK", ...}` if successful along with registration response received
+     */
+    static registerCredential(input: { registrationOptions: RegistrationOptions }): Promise<
+        | {
+              status: "OK";
+              registrationResponse: RegistrationResponseJSON;
+          }
+        | {
+              status: "AUTHENTICATOR_ALREADY_REGISTERED";
+          }
+        | {
+              status: "FAILED_TO_REGISTER_USER";
+              error: any;
+          }
+    >;
+    /**
+     * Authenticate the credential with the passed options by using native webauthn functions.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param authenticationOptions Options to pass for the authentication.
+     *
+     * @returns `{ status: "OK", ...}` if successful along with authentication response received
+     */
+    static authenticateCredential(input: { authenticationOptions: AuthenticationOptions }): Promise<
+        | {
+              status: "OK";
+              authenticationResponse: AuthenticationResponseJSON;
+          }
+        | {
+              status: "FAILED_TO_AUTHENTICATE_USER";
+              error: any;
+          }
+    >;
+    /**
      * Register the new device and signup the user with the passed email ID.
      *
      * It uses `@simplewebauthn/browser` to make the webauthn calls.
@@ -284,7 +333,11 @@ export default class RecipeWrapper {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
      */
-    static registerAndSignUp(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+    static registerCredentialWithSignUp(input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }): Promise<
         | {
               status: "OK";
               user: User;
@@ -329,6 +382,10 @@ export default class RecipeWrapper {
         | {
               status: "AUTHENTICATOR_ALREADY_REGISTERED";
           }
+        | {
+              status: "FAILED_TO_REGISTER_USER";
+              error: any;
+          }
     >;
     /**
      * Authenticate the user and sign them in after verifying their identity.
@@ -343,7 +400,11 @@ export default class RecipeWrapper {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
      */
-    static authenticateAndSignIn(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+    static authenticateCredentialWithSignIn(input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }): Promise<
         | {
               status: "OK";
               user: User;
@@ -362,6 +423,10 @@ export default class RecipeWrapper {
               reason: string;
               fetchResponse: Response;
           }
+        | {
+              status: "FAILED_TO_AUTHENTICATE_USER";
+              error: any;
+          }
         | GeneralErrorResponse
     >;
     /**
@@ -377,7 +442,7 @@ export default class RecipeWrapper {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
      */
-    static registerAndRecoverAccount(input: {
+    static registerCredentialWithRecoverAccount(input: {
         recoverAccountToken: string;
         options?: RecipeFunctionOptions;
         userContext: any;
@@ -421,29 +486,38 @@ export default class RecipeWrapper {
         | {
               status: "AUTHENTICATOR_ALREADY_REGISTERED";
           }
+        | {
+              status: "FAILED_TO_REGISTER_USER";
+              error: any;
+          }
     >;
 }
 declare const init: typeof RecipeWrapper.init;
-declare const registerOptions: typeof RecipeWrapper.registerOptions;
-declare const signInOptions: typeof RecipeWrapper.signInOptions;
+declare const getRegisterOptions: typeof RecipeWrapper.getRegisterOptions;
+declare const getSignInOptions: typeof RecipeWrapper.getSignInOptions;
 declare const signUp: typeof RecipeWrapper.signUp;
 declare const signIn: typeof RecipeWrapper.signIn;
-declare const emailExists: typeof RecipeWrapper.emailExists;
+declare const getEmailExists: typeof RecipeWrapper.getEmailExists;
 declare const generateRecoverAccountToken: typeof RecipeWrapper.generateRecoverAccountToken;
 declare const recoverAccount: typeof RecipeWrapper.recoverAccount;
-declare const registerAndSignup: typeof RecipeWrapper.registerAndSignUp;
-declare const authenticateAndSignIn: typeof RecipeWrapper.authenticateAndSignIn;
-declare const registerAndRecoverAccount: typeof RecipeWrapper.registerAndRecoverAccount;
+declare const registerCredentialWithSignUp: typeof RecipeWrapper.registerCredentialWithSignUp;
+declare const authenticateCredentialWithSignIn: typeof RecipeWrapper.authenticateCredentialWithSignIn;
+declare const registerCredentialWithRecoverAccount: typeof RecipeWrapper.registerCredentialWithRecoverAccount;
+declare const registerCredential: typeof RecipeWrapper.registerCredential;
+declare const authenticateCredential: typeof RecipeWrapper.authenticateCredential;
 export {
     init,
-    registerOptions,
-    signInOptions,
+    getRegisterOptions,
+    getSignInOptions,
     signUp,
     signIn,
-    emailExists,
+    getEmailExists,
     generateRecoverAccountToken,
     recoverAccount,
-    registerAndSignup,
-    authenticateAndSignIn,
-    registerAndRecoverAccount,
+    registerCredentialWithSignUp,
+    authenticateCredentialWithSignIn,
+    registerCredentialWithRecoverAccount,
+    registerCredential,
+    authenticateCredential,
+    RecipeInterface,
 };

--- a/lib/build/recipe/webauthn/index.d.ts
+++ b/lib/build/recipe/webauthn/index.d.ts
@@ -136,27 +136,34 @@ export default class RecipeWrapper {
         | {
               status: "OK";
               user: User;
+              fetchResponse: Response;
           }
         | GeneralErrorResponse
         | {
               status: "SIGN_UP_NOT_ALLOWED";
               reason: string;
+              fetchResponse: Response;
           }
         | {
               status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
           }
         | {
               status: "GENERATED_OPTIONS_NOT_FOUND_ERROR";
+              fetchResponse: Response;
           }
         | {
               status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
           }
         | {
               status: "INVALID_AUTHENTICATOR_ERROR";
               reason: string;
+              fetchResponse: Response;
           }
         | {
               status: "EMAIL_ALREADY_EXISTS_ERROR";
+              fetchResponse: Response;
           }
     >;
     /**

--- a/lib/build/recipe/webauthn/index.js
+++ b/lib/build/recipe/webauthn/index.js
@@ -28,16 +28,18 @@ var __assign =
         return __assign.apply(this, arguments);
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.registerAndRecoverAccount =
-    exports.authenticateAndSignIn =
-    exports.registerAndSignup =
+exports.authenticateCredential =
+    exports.registerCredential =
+    exports.registerCredentialWithRecoverAccount =
+    exports.authenticateCredentialWithSignIn =
+    exports.registerCredentialWithSignUp =
     exports.recoverAccount =
     exports.generateRecoverAccountToken =
-    exports.emailExists =
+    exports.getEmailExists =
     exports.signIn =
     exports.signUp =
-    exports.signInOptions =
-    exports.registerOptions =
+    exports.getSignInOptions =
+    exports.getRegisterOptions =
     exports.init =
         void 0;
 var utils_1 = require("../../utils");
@@ -61,8 +63,8 @@ var RecipeWrapper = /** @class */ (function () {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the created webauthn details (challenge, etc.)
      */
-    RecipeWrapper.registerOptions = function (input) {
-        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerOptions(
+    RecipeWrapper.getRegisterOptions = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.getRegisterOptions(
             __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
@@ -82,8 +84,8 @@ var RecipeWrapper = /** @class */ (function () {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the webauthn options (challenge, etc.)
      */
-    RecipeWrapper.signInOptions = function (input) {
-        return recipe_1.default.getInstanceOrThrow().recipeImplementation.signInOptions(
+    RecipeWrapper.getSignInOptions = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.getSignInOptions(
             __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
@@ -143,8 +145,8 @@ var RecipeWrapper = /** @class */ (function () {
      *
      * @returns `{ status: "OK", ...}` if successful along with a boolean indicating existence
      */
-    RecipeWrapper.emailExists = function (input) {
-        return recipe_1.default.getInstanceOrThrow().recipeImplementation.emailExists(
+    RecipeWrapper.getEmailExists = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.getEmailExists(
             __assign(__assign({}, input), {
                 userContext: input === null || input === void 0 ? void 0 : input.userContext,
             })
@@ -191,6 +193,30 @@ var RecipeWrapper = /** @class */ (function () {
         );
     };
     /**
+     * Register credential with the passed options by using native webauthn functions.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param registrationOptions Options to pass for the registration.
+     *
+     * @returns `{ status: "OK", ...}` if successful along with registration response received
+     */
+    RecipeWrapper.registerCredential = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerCredential(input);
+    };
+    /**
+     * Authenticate the credential with the passed options by using native webauthn functions.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param authenticationOptions Options to pass for the authentication.
+     *
+     * @returns `{ status: "OK", ...}` if successful along with authentication response received
+     */
+    RecipeWrapper.authenticateCredential = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.authenticateCredential(input);
+    };
+    /**
      * Register the new device and signup the user with the passed email ID.
      *
      * It uses `@simplewebauthn/browser` to make the webauthn calls.
@@ -203,8 +229,8 @@ var RecipeWrapper = /** @class */ (function () {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
      */
-    RecipeWrapper.registerAndSignUp = function (input) {
-        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerAndSignUp(
+    RecipeWrapper.registerCredentialWithSignUp = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerCredentialWithSignUp(
             __assign(__assign({}, input), {
                 userContext: input === null || input === void 0 ? void 0 : input.userContext,
             })
@@ -223,8 +249,8 @@ var RecipeWrapper = /** @class */ (function () {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
      */
-    RecipeWrapper.authenticateAndSignIn = function (input) {
-        return recipe_1.default.getInstanceOrThrow().recipeImplementation.authenticateAndSignIn(
+    RecipeWrapper.authenticateCredentialWithSignIn = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.authenticateCredentialWithSignIn(
             __assign(__assign({}, input), {
                 userContext: input === null || input === void 0 ? void 0 : input.userContext,
             })
@@ -243,8 +269,8 @@ var RecipeWrapper = /** @class */ (function () {
      *
      * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
      */
-    RecipeWrapper.registerAndRecoverAccount = function (input) {
-        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerAndRecoverAccount(
+    RecipeWrapper.registerCredentialWithRecoverAccount = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerCredentialWithRecoverAccount(
             __assign(__assign({}, input), {
                 userContext: input === null || input === void 0 ? void 0 : input.userContext,
             })
@@ -255,23 +281,27 @@ var RecipeWrapper = /** @class */ (function () {
 exports.default = RecipeWrapper;
 var init = RecipeWrapper.init;
 exports.init = init;
-var registerOptions = RecipeWrapper.registerOptions;
-exports.registerOptions = registerOptions;
-var signInOptions = RecipeWrapper.signInOptions;
-exports.signInOptions = signInOptions;
+var getRegisterOptions = RecipeWrapper.getRegisterOptions;
+exports.getRegisterOptions = getRegisterOptions;
+var getSignInOptions = RecipeWrapper.getSignInOptions;
+exports.getSignInOptions = getSignInOptions;
 var signUp = RecipeWrapper.signUp;
 exports.signUp = signUp;
 var signIn = RecipeWrapper.signIn;
 exports.signIn = signIn;
-var emailExists = RecipeWrapper.emailExists;
-exports.emailExists = emailExists;
+var getEmailExists = RecipeWrapper.getEmailExists;
+exports.getEmailExists = getEmailExists;
 var generateRecoverAccountToken = RecipeWrapper.generateRecoverAccountToken;
 exports.generateRecoverAccountToken = generateRecoverAccountToken;
 var recoverAccount = RecipeWrapper.recoverAccount;
 exports.recoverAccount = recoverAccount;
-var registerAndSignup = RecipeWrapper.registerAndSignUp;
-exports.registerAndSignup = registerAndSignup;
-var authenticateAndSignIn = RecipeWrapper.authenticateAndSignIn;
-exports.authenticateAndSignIn = authenticateAndSignIn;
-var registerAndRecoverAccount = RecipeWrapper.registerAndRecoverAccount;
-exports.registerAndRecoverAccount = registerAndRecoverAccount;
+var registerCredentialWithSignUp = RecipeWrapper.registerCredentialWithSignUp;
+exports.registerCredentialWithSignUp = registerCredentialWithSignUp;
+var authenticateCredentialWithSignIn = RecipeWrapper.authenticateCredentialWithSignIn;
+exports.authenticateCredentialWithSignIn = authenticateCredentialWithSignIn;
+var registerCredentialWithRecoverAccount = RecipeWrapper.registerCredentialWithRecoverAccount;
+exports.registerCredentialWithRecoverAccount = registerCredentialWithRecoverAccount;
+var registerCredential = RecipeWrapper.registerCredential;
+exports.registerCredential = registerCredential;
+var authenticateCredential = RecipeWrapper.authenticateCredential;
+exports.authenticateCredential = authenticateCredential;

--- a/lib/build/recipe/webauthn/index.js
+++ b/lib/build/recipe/webauthn/index.js
@@ -28,7 +28,10 @@ var __assign =
         return __assign.apply(this, arguments);
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.recoverAccount =
+exports.registerAndRecoverAccount =
+    exports.authenticateAndSignIn =
+    exports.registerAndSignup =
+    exports.recoverAccount =
     exports.generateRecoverAccountToken =
     exports.emailExists =
     exports.signIn =
@@ -187,6 +190,66 @@ var RecipeWrapper = /** @class */ (function () {
             })
         );
     };
+    /**
+     * Register the new device and signup the user with the passed email ID.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param email Email of the user to register and signup
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    RecipeWrapper.registerAndSignUp = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerAndSignUp(
+            __assign(__assign({}, input), {
+                userContext: input === null || input === void 0 ? void 0 : input.userContext,
+            })
+        );
+    };
+    /**
+     * Authenticate the user and sign them in after verifying their identity.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param email Email of the user to authenticate and signin
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    RecipeWrapper.authenticateAndSignIn = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.authenticateAndSignIn(
+            __assign(__assign({}, input), {
+                userContext: input === null || input === void 0 ? void 0 : input.userContext,
+            })
+        );
+    };
+    /**
+     * Register the new device and recover the user's account with the recover token.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param recoverAccountToken Recovery token for the user's account
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    RecipeWrapper.registerAndRecoverAccount = function (input) {
+        return recipe_1.default.getInstanceOrThrow().recipeImplementation.registerAndRecoverAccount(
+            __assign(__assign({}, input), {
+                userContext: input === null || input === void 0 ? void 0 : input.userContext,
+            })
+        );
+    };
     return RecipeWrapper;
 })();
 exports.default = RecipeWrapper;
@@ -206,3 +269,9 @@ var generateRecoverAccountToken = RecipeWrapper.generateRecoverAccountToken;
 exports.generateRecoverAccountToken = generateRecoverAccountToken;
 var recoverAccount = RecipeWrapper.recoverAccount;
 exports.recoverAccount = recoverAccount;
+var registerAndSignup = RecipeWrapper.registerAndSignUp;
+exports.registerAndSignup = registerAndSignup;
+var authenticateAndSignIn = RecipeWrapper.authenticateAndSignIn;
+exports.authenticateAndSignIn = authenticateAndSignIn;
+var registerAndRecoverAccount = RecipeWrapper.registerAndRecoverAccount;
+exports.registerAndRecoverAccount = registerAndRecoverAccount;

--- a/lib/build/recipe/webauthn/recipeImplementation.js
+++ b/lib/build/recipe/webauthn/recipeImplementation.js
@@ -166,7 +166,7 @@ var browser_1 = require("@simplewebauthn/browser");
 function getRecipeImplementation(recipeImplInput) {
     var querier = new querier_1.default(recipeImplInput.recipeId, recipeImplInput.appInfo);
     return {
-        registerOptions: function (_a) {
+        getRegisterOptions: function (_a) {
             var options = _a.options,
                 userContext = _a.userContext,
                 email = _a.email,
@@ -215,7 +215,7 @@ function getRecipeImplementation(recipeImplInput) {
                 });
             });
         },
-        signInOptions: function (_a) {
+        getSignInOptions: function (_a) {
             var email = _a.email,
                 options = _a.options,
                 userContext = _a.userContext;
@@ -360,7 +360,7 @@ function getRecipeImplementation(recipeImplInput) {
                 });
             });
         },
-        emailExists: function (_a) {
+        getEmailExists: function (_a) {
             var email = _a.email,
                 options = _a.options,
                 userContext = _a.userContext;
@@ -502,18 +502,57 @@ function getRecipeImplementation(recipeImplInput) {
                 });
             });
         },
-        registerAndSignUp: function (_a) {
+        registerCredential: function (_a) {
+            var registrationOptions = _a.registrationOptions;
+            return __awaiter(this, void 0, void 0, function () {
+                var registrationResponse, error_1;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            _b.trys.push([0, 2, , 3]);
+                            return [
+                                4 /*yield*/,
+                                (0, browser_1.startRegistration)({ optionsJSON: registrationOptions }),
+                            ];
+                        case 1:
+                            registrationResponse = _b.sent();
+                            return [3 /*break*/, 3];
+                        case 2:
+                            error_1 = _b.sent();
+                            if (error_1.name === "InvalidStateError") {
+                                return [2 /*return*/, { status: "AUTHENTICATOR_ALREADY_REGISTERED" }];
+                            }
+                            return [
+                                2 /*return*/,
+                                {
+                                    status: "FAILED_TO_REGISTER_USER",
+                                    error: error_1,
+                                },
+                            ];
+                        case 3:
+                            return [
+                                2 /*return*/,
+                                {
+                                    status: "OK",
+                                    registrationResponse: registrationResponse,
+                                },
+                            ];
+                    }
+                });
+            });
+        },
+        registerCredentialWithSignUp: function (_a) {
             var email = _a.email,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
-                var registrationOptions, registrationResponse, error_1;
+                var registrationOptions, registerCredentialResponse;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             return [
                                 4 /*yield*/,
-                                this.registerOptions({ options: options, userContext: userContext, email: email }),
+                                this.getRegisterOptions({ options: options, userContext: userContext, email: email }),
                             ];
                         case 1:
                             registrationOptions = _b.sent();
@@ -537,33 +576,22 @@ function getRecipeImplementation(recipeImplInput) {
                                 }
                                 return [2 /*return*/, registrationOptions];
                             }
-                            _b.label = 2;
+                            return [4 /*yield*/, this.registerCredential({ registrationOptions: registrationOptions })];
                         case 2:
-                            _b.trys.push([2, 4, , 5]);
-                            return [
-                                4 /*yield*/,
-                                (0, browser_1.startRegistration)({ optionsJSON: registrationOptions }),
-                            ];
-                        case 3:
-                            registrationResponse = _b.sent();
-                            return [3 /*break*/, 5];
-                        case 4:
-                            error_1 = _b.sent();
-                            if (error_1.name === "InvalidStateError") {
-                                return [2 /*return*/, { status: "AUTHENTICATOR_ALREADY_REGISTERED" }];
+                            registerCredentialResponse = _b.sent();
+                            if (registerCredentialResponse.status !== "OK") {
+                                return [2 /*return*/, registerCredentialResponse];
                             }
-                            throw error_1;
-                        case 5:
                             return [
                                 4 /*yield*/,
                                 this.signUp({
                                     webauthnGeneratedOptionsId: registrationOptions.webauthnGeneratedOptionsId,
-                                    credential: registrationResponse,
+                                    credential: registerCredentialResponse.registrationResponse,
                                     options: options,
                                     userContext: userContext,
                                 }),
                             ];
-                        case 6:
+                        case 3:
                             // We should have a valid registration response for the passed credentials
                             // and we are good to go ahead and verify them.
                             return [2 /*return*/, _b.sent()];
@@ -571,18 +599,54 @@ function getRecipeImplementation(recipeImplInput) {
                 });
             });
         },
-        authenticateAndSignIn: function (_a) {
+        authenticateCredential: function (_a) {
+            var authenticationOptions = _a.authenticationOptions;
+            return __awaiter(this, void 0, void 0, function () {
+                var authenticationResponse, error_2;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            _b.trys.push([0, 2, , 3]);
+                            return [
+                                4 /*yield*/,
+                                (0, browser_1.startAuthentication)({ optionsJSON: authenticationOptions }),
+                            ];
+                        case 1:
+                            authenticationResponse = _b.sent();
+                            return [3 /*break*/, 3];
+                        case 2:
+                            error_2 = _b.sent();
+                            return [
+                                2 /*return*/,
+                                {
+                                    status: "FAILED_TO_AUTHENTICATE_USER",
+                                    error: error_2,
+                                },
+                            ];
+                        case 3:
+                            return [
+                                2 /*return*/,
+                                {
+                                    status: "OK",
+                                    authenticationResponse: authenticationResponse,
+                                },
+                            ];
+                    }
+                });
+            });
+        },
+        authenticateCredentialWithSignIn: function (_a) {
             var email = _a.email,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
-                var signInOptions, authenticationResponse, error_2;
+                var signInOptions, authenticateCredentialResponse;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             return [
                                 4 /*yield*/,
-                                this.signInOptions({ email: email, options: options, userContext: userContext }),
+                                this.getSignInOptions({ email: email, options: options, userContext: userContext }),
                             ];
                         case 1:
                             signInOptions = _b.sent();
@@ -593,28 +657,27 @@ function getRecipeImplementation(recipeImplInput) {
                                 // We want to return the error as is if status was not "OK"
                                 return [2 /*return*/, signInOptions];
                             }
-                            _b.label = 2;
+                            return [
+                                4 /*yield*/,
+                                this.authenticateCredential({
+                                    authenticationOptions: signInOptions,
+                                }),
+                            ];
                         case 2:
-                            _b.trys.push([2, 4, , 5]);
-                            return [4 /*yield*/, (0, browser_1.startAuthentication)({ optionsJSON: signInOptions })];
-                        case 3:
-                            authenticationResponse = _b.sent();
-                            return [3 /*break*/, 5];
-                        case 4:
-                            error_2 = _b.sent();
-                            // TODO: Do we need to do something with the error besides throwing it?
-                            throw error_2;
-                        case 5:
+                            authenticateCredentialResponse = _b.sent();
+                            if (authenticateCredentialResponse.status !== "OK") {
+                                return [2 /*return*/, authenticateCredentialResponse];
+                            }
                             return [
                                 4 /*yield*/,
                                 this.signIn({
                                     webauthnGeneratedOptionsId: signInOptions.webauthnGeneratedOptionsId,
-                                    credential: authenticationResponse,
+                                    credential: authenticateCredentialResponse.authenticationResponse,
                                     options: options,
                                     userContext: userContext,
                                 }),
                             ];
-                        case 6:
+                        case 3:
                             // We should have a valid authentication response at this point so we can
                             // go ahead and sign in the user.
                             return [2 /*return*/, _b.sent()];
@@ -622,18 +685,18 @@ function getRecipeImplementation(recipeImplInput) {
                 });
             });
         },
-        registerAndRecoverAccount: function (_a) {
+        registerCredentialWithRecoverAccount: function (_a) {
             var recoverAccountToken = _a.recoverAccountToken,
                 options = _a.options,
                 userContext = _a.userContext;
             return __awaiter(this, void 0, void 0, function () {
-                var registrationOptions, registrationResponse, error_3;
+                var registrationOptions, registerCredentialResponse;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             return [
                                 4 /*yield*/,
-                                this.registerOptions({
+                                this.getRegisterOptions({
                                     options: options,
                                     userContext: userContext,
                                     recoverAccountToken: recoverAccountToken,
@@ -659,34 +722,23 @@ function getRecipeImplementation(recipeImplInput) {
                                 }
                                 return [2 /*return*/, registrationOptions];
                             }
-                            _b.label = 2;
+                            return [4 /*yield*/, this.registerCredential({ registrationOptions: registrationOptions })];
                         case 2:
-                            _b.trys.push([2, 4, , 5]);
-                            return [
-                                4 /*yield*/,
-                                (0, browser_1.startRegistration)({ optionsJSON: registrationOptions }),
-                            ];
-                        case 3:
-                            registrationResponse = _b.sent();
-                            return [3 /*break*/, 5];
-                        case 4:
-                            error_3 = _b.sent();
-                            if (error_3.name === "InvalidStateError") {
-                                return [2 /*return*/, { status: "AUTHENTICATOR_ALREADY_REGISTERED" }];
+                            registerCredentialResponse = _b.sent();
+                            if (registerCredentialResponse.status !== "OK") {
+                                return [2 /*return*/, registerCredentialResponse];
                             }
-                            throw error_3;
-                        case 5:
                             return [
                                 4 /*yield*/,
                                 this.recoverAccount({
                                     token: recoverAccountToken,
                                     webauthnGeneratedOptionsId: registrationOptions.webauthnGeneratedOptionsId,
-                                    credential: registrationResponse,
+                                    credential: registerCredentialResponse.registrationResponse,
                                     options: options,
                                     userContext: userContext,
                                 }),
                             ];
-                        case 6:
+                        case 3:
                             return [2 /*return*/, _b.sent()];
                     }
                 });

--- a/lib/build/recipe/webauthn/recipeImplementation.js
+++ b/lib/build/recipe/webauthn/recipeImplementation.js
@@ -162,6 +162,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getRecipeImplementation = void 0;
 var querier_1 = require("../../querier");
 var recipe_1 = require("../multitenancy/recipe");
+var browser_1 = require("@simplewebauthn/browser");
 function getRecipeImplementation(recipeImplInput) {
     var querier = new querier_1.default(recipeImplInput.recipeId, recipeImplInput.appInfo);
     return {
@@ -497,6 +498,196 @@ function getRecipeImplementation(recipeImplInput) {
                         case 2:
                             (_b = _e.sent()), (jsonBody = _b.jsonBody), (fetchResponse = _b.fetchResponse);
                             return [2 /*return*/, __assign(__assign({}, jsonBody), { fetchResponse: fetchResponse })];
+                    }
+                });
+            });
+        },
+        registerAndSignUp: function (_a) {
+            var email = _a.email,
+                options = _a.options,
+                userContext = _a.userContext;
+            return __awaiter(this, void 0, void 0, function () {
+                var registrationOptions, registrationResponse, error_1;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            return [
+                                4 /*yield*/,
+                                this.registerOptions({ options: options, userContext: userContext, email: email }),
+                            ];
+                        case 1:
+                            registrationOptions = _b.sent();
+                            if (
+                                (registrationOptions === null || registrationOptions === void 0
+                                    ? void 0
+                                    : registrationOptions.status) !== "OK"
+                            ) {
+                                // If we did not get an OK status, we need to return the error as is.
+                                // If the `status` is `RECOVER_ACCOUNT_TOKEN_INVALID_ERROR`, we need to throw an
+                                // error since that should never happen as we are registering with an email
+                                // and not a token.
+                                if (
+                                    (registrationOptions === null || registrationOptions === void 0
+                                        ? void 0
+                                        : registrationOptions.status) === "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR"
+                                ) {
+                                    throw new Error(
+                                        "Got `RECOVER_ACCOUNT_TOKEN_INVALID_ERROR` status that should never happen"
+                                    );
+                                }
+                                return [2 /*return*/, registrationOptions];
+                            }
+                            _b.label = 2;
+                        case 2:
+                            _b.trys.push([2, 4, , 5]);
+                            return [
+                                4 /*yield*/,
+                                (0, browser_1.startRegistration)({ optionsJSON: registrationOptions }),
+                            ];
+                        case 3:
+                            registrationResponse = _b.sent();
+                            return [3 /*break*/, 5];
+                        case 4:
+                            error_1 = _b.sent();
+                            if (error_1.name === "InvalidStateError") {
+                                return [2 /*return*/, { status: "AUTHENTICATOR_ALREADY_REGISTERED" }];
+                            }
+                            throw error_1;
+                        case 5:
+                            return [
+                                4 /*yield*/,
+                                this.signUp({
+                                    webauthnGeneratedOptionsId: registrationOptions.webauthnGeneratedOptionsId,
+                                    credential: registrationResponse,
+                                    options: options,
+                                    userContext: userContext,
+                                }),
+                            ];
+                        case 6:
+                            // We should have a valid registration response for the passed credentials
+                            // and we are good to go ahead and verify them.
+                            return [2 /*return*/, _b.sent()];
+                    }
+                });
+            });
+        },
+        authenticateAndSignIn: function (_a) {
+            var email = _a.email,
+                options = _a.options,
+                userContext = _a.userContext;
+            return __awaiter(this, void 0, void 0, function () {
+                var signInOptions, authenticationResponse, error_2;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            return [
+                                4 /*yield*/,
+                                this.signInOptions({ email: email, options: options, userContext: userContext }),
+                            ];
+                        case 1:
+                            signInOptions = _b.sent();
+                            if (
+                                (signInOptions === null || signInOptions === void 0 ? void 0 : signInOptions.status) !==
+                                "OK"
+                            ) {
+                                // We want to return the error as is if status was not "OK"
+                                return [2 /*return*/, signInOptions];
+                            }
+                            _b.label = 2;
+                        case 2:
+                            _b.trys.push([2, 4, , 5]);
+                            return [4 /*yield*/, (0, browser_1.startAuthentication)({ optionsJSON: signInOptions })];
+                        case 3:
+                            authenticationResponse = _b.sent();
+                            return [3 /*break*/, 5];
+                        case 4:
+                            error_2 = _b.sent();
+                            // TODO: Do we need to do something with the error besides throwing it?
+                            throw error_2;
+                        case 5:
+                            return [
+                                4 /*yield*/,
+                                this.signIn({
+                                    webauthnGeneratedOptionsId: signInOptions.webauthnGeneratedOptionsId,
+                                    credential: authenticationResponse,
+                                    options: options,
+                                    userContext: userContext,
+                                }),
+                            ];
+                        case 6:
+                            // We should have a valid authentication response at this point so we can
+                            // go ahead and sign in the user.
+                            return [2 /*return*/, _b.sent()];
+                    }
+                });
+            });
+        },
+        registerAndRecoverAccount: function (_a) {
+            var recoverAccountToken = _a.recoverAccountToken,
+                options = _a.options,
+                userContext = _a.userContext;
+            return __awaiter(this, void 0, void 0, function () {
+                var registrationOptions, registrationResponse, error_3;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            return [
+                                4 /*yield*/,
+                                this.registerOptions({
+                                    options: options,
+                                    userContext: userContext,
+                                    recoverAccountToken: recoverAccountToken,
+                                }),
+                            ];
+                        case 1:
+                            registrationOptions = _b.sent();
+                            if (
+                                (registrationOptions === null || registrationOptions === void 0
+                                    ? void 0
+                                    : registrationOptions.status) !== "OK"
+                            ) {
+                                // If we did not get an OK status, we need to return the error as is.
+                                // If the `status` is `INVALID_EMAIL_ERROR`, we need to throw an
+                                // error since that should never happen as we are registering with a recover account token
+                                // and not an email ID.
+                                if (
+                                    (registrationOptions === null || registrationOptions === void 0
+                                        ? void 0
+                                        : registrationOptions.status) === "INVALID_EMAIL_ERROR"
+                                ) {
+                                    throw new Error("Got `INVALID_EMAIL_ERROR` status that should never happen");
+                                }
+                                return [2 /*return*/, registrationOptions];
+                            }
+                            _b.label = 2;
+                        case 2:
+                            _b.trys.push([2, 4, , 5]);
+                            return [
+                                4 /*yield*/,
+                                (0, browser_1.startRegistration)({ optionsJSON: registrationOptions }),
+                            ];
+                        case 3:
+                            registrationResponse = _b.sent();
+                            return [3 /*break*/, 5];
+                        case 4:
+                            error_3 = _b.sent();
+                            if (error_3.name === "InvalidStateError") {
+                                return [2 /*return*/, { status: "AUTHENTICATOR_ALREADY_REGISTERED" }];
+                            }
+                            throw error_3;
+                        case 5:
+                            return [
+                                4 /*yield*/,
+                                this.recoverAccount({
+                                    token: recoverAccountToken,
+                                    webauthnGeneratedOptionsId: registrationOptions.webauthnGeneratedOptionsId,
+                                    credential: registrationResponse,
+                                    options: options,
+                                    userContext: userContext,
+                                }),
+                            ];
+                        case 6:
+                            return [2 /*return*/, _b.sent()];
                     }
                 });
             });

--- a/lib/build/recipe/webauthn/types.d.ts
+++ b/lib/build/recipe/webauthn/types.d.ts
@@ -1,3 +1,4 @@
+import { AuthenticationResponseJSON, RegistrationResponseJSON } from "@simplewebauthn/browser";
 import { GeneralErrorResponse, User } from "../../types";
 import {
     NormalisedInputType as AuthRecipeNormalisedInputType,
@@ -49,7 +50,7 @@ export declare type CredentialPayload = {
         userHandle: string;
     };
     authenticatorAttachment: "platform" | "cross-platform";
-    clientExtensionResults: Record<string, unknown>;
+    clientExtensionResults: any;
     type: "public-key";
 };
 export declare type RecipeInterface = {
@@ -128,7 +129,7 @@ export declare type RecipeInterface = {
     >;
     signUp: (input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -167,7 +168,7 @@ export declare type RecipeInterface = {
     >;
     signIn: (input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -214,7 +215,7 @@ export declare type RecipeInterface = {
     recoverAccount: (input: {
         token: string;
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -245,6 +246,118 @@ export declare type RecipeInterface = {
               status: "INVALID_AUTHENTICATOR_ERROR";
               reason: string;
               fetchResponse: Response;
+          }
+    >;
+    registerAndSignUp: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_EMAIL_ERROR";
+              err: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | {
+              status: "SIGN_UP_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "GENERATED_OPTIONS_NOT_FOUND_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_AUTHENTICATOR_ERROR";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "EMAIL_ALREADY_EXISTS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "AUTHENTICATOR_ALREADY_REGISTERED";
+          }
+    >;
+    authenticateAndSignIn: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "SIGN_IN_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+    >;
+    registerAndRecoverAccount: (input: {
+        recoverAccountToken: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }) => Promise<
+        | {
+              status: "OK";
+              user: User;
+              email: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | {
+              status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_CREDENTIALS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "GENERATED_OPTIONS_NOT_FOUND_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_AUTHENTICATOR_ERROR";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "AUTHENTICATOR_ALREADY_REGISTERED";
           }
     >;
 };

--- a/lib/build/recipe/webauthn/types.d.ts
+++ b/lib/build/recipe/webauthn/types.d.ts
@@ -53,8 +53,47 @@ export declare type CredentialPayload = {
     clientExtensionResults: any;
     type: "public-key";
 };
+export declare type RegistrationOptions = {
+    status: "OK";
+    webauthnGeneratedOptionsId: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    user: {
+        id: string;
+        name: string;
+        displayName: string;
+    };
+    challenge: string;
+    timeout: number;
+    excludeCredentials: {
+        id: string;
+        type: "public-key";
+        transports: ("ble" | "hybrid" | "internal" | "nfc" | "usb")[];
+    }[];
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        alg: number;
+        type: "public-key";
+    }[];
+    authenticatorSelection: {
+        requireResidentKey: boolean;
+        residentKey: ResidentKey;
+        userVerification: UserVerification;
+    };
+    fetchResponse: Response;
+};
+export declare type AuthenticationOptions = {
+    status: "OK";
+    webauthnGeneratedOptionsId: string;
+    challenge: string;
+    timeout: number;
+    userVerification: UserVerification;
+    fetchResponse: Response;
+};
 export declare type RecipeInterface = {
-    registerOptions: (
+    getRegisterOptions: (
         input: {
             options?: RecipeFunctionOptions;
             userContext: any;
@@ -67,37 +106,7 @@ export declare type RecipeInterface = {
               }
         )
     ) => Promise<
-        | {
-              status: "OK";
-              webauthnGeneratedOptionsId: string;
-              rp: {
-                  id: string;
-                  name: string;
-              };
-              user: {
-                  id: string;
-                  name: string;
-                  displayName: string;
-              };
-              challenge: string;
-              timeout: number;
-              excludeCredentials: {
-                  id: string;
-                  type: "public-key";
-                  transports: ("ble" | "hybrid" | "internal" | "nfc" | "usb")[];
-              }[];
-              attestation: "none" | "indirect" | "direct" | "enterprise";
-              pubKeyCredParams: {
-                  alg: number;
-                  type: "public-key";
-              }[];
-              authenticatorSelection: {
-                  requireResidentKey: boolean;
-                  residentKey: ResidentKey;
-                  userVerification: UserVerification;
-              };
-              fetchResponse: Response;
-          }
+        | RegistrationOptions
         | {
               status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
               fetchResponse: Response;
@@ -112,15 +121,8 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
     >;
-    signInOptions: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
-        | {
-              status: "OK";
-              webauthnGeneratedOptionsId: string;
-              challenge: string;
-              timeout: number;
-              userVerification: UserVerification;
-              fetchResponse: Response;
-          }
+    getSignInOptions: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+        | AuthenticationOptions
         | {
               status: "INVALID_GENERATED_OPTIONS_ERROR";
               fetchResponse: Response;
@@ -188,7 +190,7 @@ export declare type RecipeInterface = {
           }
         | GeneralErrorResponse
     >;
-    emailExists: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+    getEmailExists: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
         | {
               status: "OK";
               exists: boolean;
@@ -248,7 +250,34 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
     >;
-    registerAndSignUp: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+    registerCredential: (input: { registrationOptions: RegistrationOptions }) => Promise<
+        | {
+              status: "OK";
+              registrationResponse: RegistrationResponseJSON;
+          }
+        | {
+              status: "AUTHENTICATOR_ALREADY_REGISTERED";
+          }
+        | {
+              status: "FAILED_TO_REGISTER_USER";
+              error: any;
+          }
+    >;
+    authenticateCredential: (input: { authenticationOptions: AuthenticationOptions }) => Promise<
+        | {
+              status: "OK";
+              authenticationResponse: AuthenticationResponseJSON;
+          }
+        | {
+              status: "FAILED_TO_AUTHENTICATE_USER";
+              error: any;
+          }
+    >;
+    registerCredentialWithSignUp: (input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }) => Promise<
         | {
               status: "OK";
               user: User;
@@ -278,10 +307,6 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
         | {
-              status: "INVALID_GENERATED_OPTIONS_ERROR";
-              fetchResponse: Response;
-          }
-        | {
               status: "INVALID_AUTHENTICATOR_ERROR";
               reason: string;
               fetchResponse: Response;
@@ -293,8 +318,16 @@ export declare type RecipeInterface = {
         | {
               status: "AUTHENTICATOR_ALREADY_REGISTERED";
           }
+        | {
+              status: "FAILED_TO_REGISTER_USER";
+              error: any;
+          }
     >;
-    authenticateAndSignIn: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+    authenticateCredentialWithSignIn: (input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }) => Promise<
         | {
               status: "OK";
               user: User;
@@ -313,9 +346,13 @@ export declare type RecipeInterface = {
               reason: string;
               fetchResponse: Response;
           }
+        | {
+              status: "FAILED_TO_AUTHENTICATE_USER";
+              error: any;
+          }
         | GeneralErrorResponse
     >;
-    registerAndRecoverAccount: (input: {
+    registerCredentialWithRecoverAccount: (input: {
         recoverAccountToken: string;
         options?: RecipeFunctionOptions;
         userContext: any;
@@ -348,16 +385,16 @@ export declare type RecipeInterface = {
               fetchResponse: Response;
           }
         | {
-              status: "INVALID_GENERATED_OPTIONS_ERROR";
-              fetchResponse: Response;
-          }
-        | {
               status: "INVALID_AUTHENTICATOR_ERROR";
               reason: string;
               fetchResponse: Response;
           }
         | {
               status: "AUTHENTICATOR_ALREADY_REGISTERED";
+          }
+        | {
+              status: "FAILED_TO_REGISTER_USER";
+              error: any;
           }
     >;
 };

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -202,11 +202,13 @@ export default class RecipeWrapper {
         | {
               status: "OK";
               user: User;
+              fetchResponse: Response;
           }
-        | { status: "INVALID_CREDENTIALS_ERROR" }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
         | {
               status: "SIGN_IN_NOT_ALLOWED";
               reason: string;
+              fetchResponse: Response;
           }
         | GeneralErrorResponse
     > {
@@ -231,6 +233,7 @@ export default class RecipeWrapper {
         | {
               status: "OK";
               exists: boolean;
+              fetchResponse: Response;
           }
         | GeneralErrorResponse
     > {
@@ -258,8 +261,9 @@ export default class RecipeWrapper {
     }): Promise<
         | {
               status: "OK";
+              fetchResponse: Response;
           }
-        | { status: "RECOVER_ACCOUNT_NOT_ALLOWED"; reason: string }
+        | { status: "RECOVER_ACCOUNT_NOT_ALLOWED"; reason: string; fetchResponse: Response }
         | GeneralErrorResponse
     > {
         return Recipe.getInstanceOrThrow().recipeImplementation.generateRecoverAccountToken({
@@ -294,13 +298,14 @@ export default class RecipeWrapper {
               status: "OK";
               user: User;
               email: string;
+              fetchResponse: Response;
           }
         | GeneralErrorResponse
-        | { status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR" }
-        | { status: "INVALID_CREDENTIALS_ERROR" }
-        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR" }
-        | { status: "INVALID_GENERATED_OPTIONS_ERROR" }
-        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string }
+        | { status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
     > {
         return Recipe.getInstanceOrThrow().recipeImplementation.recoverAccount({
             ...input,

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -299,8 +299,7 @@ export default class RecipeWrapper {
     }
 
     /**
-     * This function will handle getting registration options for the email ID, registering the user using
-     * webauthn and then signing up the user.
+     * Register the new device and signup the user with the passed email ID.
      *
      * It uses `@simplewebauthn/browser` to make the webauthn calls.
      *
@@ -382,6 +381,52 @@ export default class RecipeWrapper {
             userContext: input?.userContext,
         });
     }
+
+    /**
+     * Register the new device and recover the user's account with the recover token.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param recoverAccountToken Recovery token for the user's account
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    static registerAndRecoverAccount(input: {
+        recoverAccountToken: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }): Promise<
+        | {
+              status: "OK";
+              user: User;
+              email: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | { status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
+        | { status: "AUTHENTICATOR_ALREADY_REGISTERED" }
+    > {
+        return Recipe.getInstanceOrThrow().recipeImplementation.registerAndRecoverAccount({
+            ...input,
+            userContext: input?.userContext,
+        });
+    }
 }
 
 const init = RecipeWrapper.init;
@@ -394,6 +439,7 @@ const generateRecoverAccountToken = RecipeWrapper.generateRecoverAccountToken;
 const recoverAccount = RecipeWrapper.recoverAccount;
 const registerAndSignup = RecipeWrapper.registerAndSignUp;
 const authenticateAndSignIn = RecipeWrapper.authenticateAndSignIn;
+const registerAndRecoverAccount = RecipeWrapper.registerAndRecoverAccount;
 
 export {
     init,
@@ -406,4 +452,5 @@ export {
     recoverAccount,
     registerAndSignup,
     authenticateAndSignIn,
+    registerAndRecoverAccount,
 };

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -25,6 +25,7 @@ import {
     UserVerification,
     RegistrationOptions,
     AuthenticationOptions,
+    RecipeInterface,
 } from "./types";
 
 export default class RecipeWrapper {
@@ -514,4 +515,5 @@ export {
     registerCredentialWithRecoverAccount,
     registerCredential,
     authenticateCredential,
+    RecipeInterface,
 };

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -345,6 +345,43 @@ export default class RecipeWrapper {
             userContext: input?.userContext,
         });
     }
+
+    /**
+     * Authenticate the user and sign them in after verifying their identity.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param email Email of the user to authenticate and signin
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    static authenticateAndSignIn(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | {
+              status: "SIGN_IN_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+    > {
+        return Recipe.getInstanceOrThrow().recipeImplementation.authenticateAndSignIn({
+            ...input,
+            userContext: input?.userContext,
+        });
+    }
 }
 
 const init = RecipeWrapper.init;
@@ -356,6 +393,7 @@ const emailExists = RecipeWrapper.emailExists;
 const generateRecoverAccountToken = RecipeWrapper.generateRecoverAccountToken;
 const recoverAccount = RecipeWrapper.recoverAccount;
 const registerAndSignup = RecipeWrapper.registerAndSignUp;
+const authenticateAndSignIn = RecipeWrapper.authenticateAndSignIn;
 
 export {
     init,
@@ -367,4 +405,5 @@ export {
     generateRecoverAccountToken,
     recoverAccount,
     registerAndSignup,
+    authenticateAndSignIn,
 };

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -160,17 +160,19 @@ export default class RecipeWrapper {
         | {
               status: "OK";
               user: User;
+              fetchResponse: Response;
           }
         | GeneralErrorResponse
         | {
               status: "SIGN_UP_NOT_ALLOWED";
               reason: string;
+              fetchResponse: Response;
           }
-        | { status: "INVALID_CREDENTIALS_ERROR" }
-        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR" }
-        | { status: "INVALID_GENERATED_OPTIONS_ERROR" }
-        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string }
-        | { status: "EMAIL_ALREADY_EXISTS_ERROR" }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
+        | { status: "EMAIL_ALREADY_EXISTS_ERROR"; fetchResponse: Response }
     > {
         return Recipe.getInstanceOrThrow().recipeImplementation.signUp({
             ...input,

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -13,6 +13,7 @@
  * under the License.
  */
 
+import { AuthenticationResponseJSON, RegistrationResponseJSON } from "@simplewebauthn/browser";
 import { GeneralErrorResponse, User } from "../../types";
 import { getNormalisedUserContext } from "../../utils";
 import { RecipeFunctionOptions } from "../recipeModule/types";
@@ -144,7 +145,7 @@ export default class RecipeWrapper {
      */
     static signUp(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }): Promise<
@@ -184,7 +185,7 @@ export default class RecipeWrapper {
      */
     static signIn(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }): Promise<

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -297,6 +297,54 @@ export default class RecipeWrapper {
             userContext: input?.userContext,
         });
     }
+
+    /**
+     * This function will handle getting registration options for the email ID, registering the user using
+     * webauthn and then signing up the user.
+     *
+     * It uses `@simplewebauthn/browser` to make the webauthn calls.
+     *
+     * @param email Email of the user to register and signup
+     *
+     * @param userContext (OPTIONAL) Refer to {@link https://supertokens.com/docs/emailpassword/advanced-customizations/user-context the documentation}
+     *
+     * @param options (OPTIONAL) Use this to configure additional properties (for example pre api hooks)
+     *
+     * @returns `{ status: "OK", ...}` if successful along a description of the user details (id, etc.) and email
+     */
+    static registerAndSignUp(input: { email: string; options?: RecipeFunctionOptions; userContext: any }): Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_EMAIL_ERROR";
+              err: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | {
+              status: "SIGN_UP_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
+        | { status: "EMAIL_ALREADY_EXISTS_ERROR"; fetchResponse: Response }
+        | { status: "AUTHENTICATOR_ALREADY_REGISTERED" }
+    > {
+        return Recipe.getInstanceOrThrow().recipeImplementation.registerAndSignUp({
+            ...input,
+            userContext: input?.userContext,
+        });
+    }
 }
 
 const init = RecipeWrapper.init;
@@ -307,6 +355,7 @@ const signIn = RecipeWrapper.signIn;
 const emailExists = RecipeWrapper.emailExists;
 const generateRecoverAccountToken = RecipeWrapper.generateRecoverAccountToken;
 const recoverAccount = RecipeWrapper.recoverAccount;
+const registerAndSignup = RecipeWrapper.registerAndSignUp;
 
 export {
     init,
@@ -317,4 +366,5 @@ export {
     emailExists,
     generateRecoverAccountToken,
     recoverAccount,
+    registerAndSignup,
 };

--- a/lib/ts/recipe/webauthn/recipeImplementation.ts
+++ b/lib/ts/recipe/webauthn/recipeImplementation.ts
@@ -348,6 +348,17 @@ export default function getRecipeImplementation(
                 fetchResponse,
             };
         },
+        registerAndSignUp: async function ({ email, options, userContext }) {
+            // Get the registration options by using the passed email ID.
+            const registrationOptions = await this.registerOptions({ options, userContext, email });
+            if (registrationOptions?.status !== "OK") {
+                // If we did not get an OK status, we need to return the error as is.
+                return registrationOptions;
+            }
+
+            // We should have received a valid registration options response.
+            // TODO: Pass the registration options to simplewebauthn
+        },
     };
 }
 

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -250,6 +250,7 @@ export type RecipeInterface = {
         | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
         | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
         | { status: "EMAIL_ALREADY_EXISTS_ERROR"; fetchResponse: Response }
+        | { status: "AUTHENTICATOR_ALREADY_REGISTERED" }
     >;
     authenticateAndSignIn: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
         | {

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -208,7 +208,7 @@ export type RecipeInterface = {
     recoverAccount: (input: {
         token: string;
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -296,5 +296,6 @@ export type RecipeInterface = {
         | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
         | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
         | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
+        | { status: "AUTHENTICATOR_ALREADY_REGISTERED" }
     >;
 };

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -248,7 +248,6 @@ export type RecipeInterface = {
           }
         | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
         | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
-        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
         | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
         | { status: "EMAIL_ALREADY_EXISTS_ERROR"; fetchResponse: Response }
         | { status: "AUTHENTICATOR_ALREADY_REGISTERED" }
@@ -294,7 +293,6 @@ export type RecipeInterface = {
         | { status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR"; fetchResponse: Response }
         | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
         | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
-        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
         | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
         | { status: "AUTHENTICATOR_ALREADY_REGISTERED" }
     >;

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -224,4 +224,75 @@ export type RecipeInterface = {
         | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
         | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
     >;
+    registerAndSignUp: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_EMAIL_ERROR";
+              err: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | {
+              status: "SIGN_UP_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
+        | { status: "EMAIL_ALREADY_EXISTS_ERROR"; fetchResponse: Response }
+    >;
+    authenticateAndSignIn: (input: { email: string; options?: RecipeFunctionOptions; userContext: any }) => Promise<
+        | {
+              status: "OK";
+              user: User;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | {
+              status: "SIGN_IN_NOT_ALLOWED";
+              reason: string;
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+    >;
+    registerAndRecoverAccount: (input: {
+        recoverAccountToken: string;
+        options?: RecipeFunctionOptions;
+        userContext: any;
+    }) => Promise<
+        | {
+              status: "OK";
+              user: User;
+              email: string;
+              fetchResponse: Response;
+          }
+        | {
+              status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR";
+              fetchResponse: Response;
+          }
+        | {
+              status: "INVALID_GENERATED_OPTIONS_ERROR";
+              fetchResponse: Response;
+          }
+        | GeneralErrorResponse
+        | { status: "RECOVER_ACCOUNT_TOKEN_INVALID_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_CREDENTIALS_ERROR"; fetchResponse: Response }
+        | { status: "GENERATED_OPTIONS_NOT_FOUND_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_GENERATED_OPTIONS_ERROR"; fetchResponse: Response }
+        | { status: "INVALID_AUTHENTICATOR_ERROR"; reason: string; fetchResponse: Response }
+    >;
 };

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -13,6 +13,7 @@
  * under the License.
  */
 
+import { AuthenticationResponseJSON, RegistrationResponseJSON } from "@simplewebauthn/browser";
 import { GeneralErrorResponse, User } from "../../types";
 import {
     NormalisedInputType as AuthRecipeNormalisedInputType,
@@ -71,7 +72,7 @@ export type CredentialPayload = {
         userHandle: string;
     };
     authenticatorAttachment: "platform" | "cross-platform";
-    clientExtensionResults: Record<string, unknown>;
+    clientExtensionResults: any;
     type: "public-key";
 };
 
@@ -144,7 +145,7 @@ export type RecipeInterface = {
     >;
     signUp: (input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<
@@ -167,7 +168,7 @@ export type RecipeInterface = {
     >;
     signIn: (input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationResponseJSON;
         options?: RecipeFunctionOptions;
         userContext: any;
     }) => Promise<

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
     "packages": {
         "": {
             "name": "supertokens-web-js",
-            "version": "0.14.0",
+            "version": "0.15.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@simplewebauthn/browser": "^13.0.0",
                 "supertokens-js-override": "0.0.4",
                 "supertokens-website": "^20.1.5"
             },
@@ -2217,6 +2218,11 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@simplewebauthn/browser": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.0.0.tgz",
+            "integrity": "sha512-7d/+gxoFoDQxq2EkLl/PuTIQ/rnSrA3bmr8L2Ij7bRyicJoCJX/NDGUNExyctB9nSDrEkkcrJMDkwpCYOGU3Lg=="
         },
         "node_modules/@size-limit/esbuild": {
             "version": "8.2.6",
@@ -12241,6 +12247,11 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@simplewebauthn/browser": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.0.0.tgz",
+            "integrity": "sha512-7d/+gxoFoDQxq2EkLl/PuTIQ/rnSrA3bmr8L2Ij7bRyicJoCJX/NDGUNExyctB9nSDrEkkcrJMDkwpCYOGU3Lg=="
         },
         "@size-limit/esbuild": {
             "version": "8.2.6",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     },
     "homepage": "https://github.com/supertokens/supertokens-web-js#readme",
     "dependencies": {
+        "@simplewebauthn/browser": "^13.0.0",
         "supertokens-js-override": "0.0.4",
         "supertokens-website": "^20.1.5"
     },

--- a/recipe/webauthn/index.d.ts
+++ b/recipe/webauthn/index.d.ts
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+export * from "../../lib/build/recipe/webauthn";
+import * as _default from "../../lib/build/recipe/webauthn";
+export default _default;

--- a/recipe/webauthn/index.js
+++ b/recipe/webauthn/index.js
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+exports.__esModule = true;
+__export(require("../../lib/build/recipe/webauthn"));

--- a/recipe/webauthn/types/index.d.ts
+++ b/recipe/webauthn/types/index.d.ts
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+export * from "../../../lib/build/recipe/webauthn/types";
+import * as _default from "../../../lib/build/recipe/webauthn/types";
+export default _default;

--- a/recipe/webauthn/types/index.js
+++ b/recipe/webauthn/types/index.js
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+exports.__esModule = true;
+__export(require("../../../lib/build/recipe/webauthn/types"));


### PR DESCRIPTION
## Summary of change

Adds webauthn wrapper methods around the API methods for ease of usage.

## Related issues

## Test Plan

Tests will be written later on in the auth-react repo

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `webJsInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
